### PR TITLE
Fix OSC broadcast call in listener

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -108,7 +108,7 @@ class OscListener {
   void _sendHello() {
     if (_socket == null) return;
     final msg = OSCMessage('/hello', arguments: [client.myIndex.value]);
-    _socket!.send(msg, InternetAddress('255.255.255.255'), 9000);
+    _socket!.send(msg);
   }
 
   void _markConnected() {
@@ -132,5 +132,4 @@ class OscListener {
     _helloTimer?.cancel();
     client.connected.value = false;
     print('[OSC] Listener stopped');
-  }
-}
+  }}


### PR DESCRIPTION
## Summary
- fix argument mismatch when sending OSC hello from `OscListener`

## Testing
- `flutter analyze flashlights_client` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d94ea6ad48332bba325a916abe504