### PR TITLE
Fix iOS bridging header build error

### DIFF
--- a/flashlights_client/README.md
+++ b/flashlights_client/README.md
@@ -14,3 +14,16 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+### iOS clean build checklist
+```bash
+flutter clean
+flutter pub get
+cd ios
+rm -rf Pods Podfile.lock
+pod install
+open Flashlights-ITD-Client.xcworkspace   # \u2190 NOT the .xcodeproj
+```
+
+Building the *Flashlights-ITD-Client* scheme for any simulator or
+device should now succeed.

--- a/flashlights_client/ios/Flashlights-ITD-Client/Flashlights-ITD-Client-Bridging-Header.h
+++ b/flashlights_client/ios/Flashlights-ITD-Client/Flashlights-ITD-Client-Bridging-Header.h
@@ -1,1 +1,1 @@
-#import "GeneratedPluginRegistrant.h"
+#import <GeneratedPluginRegistrant.h>

--- a/flashlights_client/ios/Podfile
+++ b/flashlights_client/ios/Podfile
@@ -4,6 +4,8 @@
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
+require_relative '../flutter_export_environment'
+
 project 'Flashlights-ITD-Client', {
   'Debug' => :debug,
   'Profile' => :release,
@@ -54,4 +56,5 @@ post_install do |installer|
     end
     app_proj.save
   end
+  flutter_post_install(installer)
 end

--- a/scripts/ci/ios_build_check.sh
+++ b/scripts/ci/ios_build_check.sh
@@ -1,0 +1,13 @@
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)/flashlights_client"
+flutter clean
+flutter pub get
+cd ios
+rm -rf Pods Podfile.lock
+pod install
+xcodebuild -workspace Flashlights-ITD-Client.xcworkspace \
+           -scheme Flashlights-ITD-Client \
+           -destination 'generic/platform=iOS Simulator' \
+           -configuration Debug \
+           build


### PR DESCRIPTION
## Summary
- include Flutter export environment in Podfile so that CocoaPods runs the Flutter build scripts
- call `flutter_post_install` during pod install
- reference `GeneratedPluginRegistrant.h` in the bridging header using angle brackets
- document iOS clean build steps
- add a CI script to exercise the iOS build

## Testing
- `scripts/ci/ios_build_check.sh` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9cc05188833284303f255e21d697