### PR TITLE
Fix OSCMessage usage for updated constructor

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -107,7 +107,7 @@ class OscListener {
   /// Broadcast a hello so servers can discover us
   void _sendHello() {
     if (_socket == null) return;
-    final msg = OSCMessage('/hello', arguments: [client.myIndex.value]);
+    final msg = OSCMessage('/hello', [client.myIndex.value]);
     _socket!.send(msg);
   }
 
@@ -131,5 +131,4 @@ class OscListener {
     _disconnectTimer?.cancel();
     _helloTimer?.cancel();
     client.connected.value = false;
-    print('[OSC] Listener stopped');
-  }}
+    print('[OSC] Listener stopped');  }}

--- a/flashlights_client/lib/network/osc_messages.dart
+++ b/flashlights_client/lib/network/osc_messages.dart
@@ -31,7 +31,7 @@ class FlashOn implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, arguments: [index, intensity]);
+    return OSCMessage(address.value, [index, intensity]);
   }
 
   static FlashOn? fromOsc(OSCMessage message) {
@@ -59,7 +59,7 @@ class FlashOff implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, arguments: [index]);
+    return OSCMessage(address.value, [index]);
   }
 
   static FlashOff? fromOsc(OSCMessage message) {
@@ -88,7 +88,7 @@ class AudioPlay implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, arguments: [index, file, gain]);
+    return OSCMessage(address.value, [index, file, gain]);
   }
 
   static AudioPlay? fromOsc(OSCMessage message) {
@@ -117,7 +117,7 @@ class AudioStop implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, arguments: [index]);
+    return OSCMessage(address.value, [index]);
   }
 
   static AudioStop? fromOsc(OSCMessage message) {
@@ -145,7 +145,7 @@ class MicRecord implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, arguments: [index, maxDuration]);
+    return OSCMessage(address.value, [index, maxDuration]);
   }
 
   static MicRecord? fromOsc(OSCMessage message) {
@@ -173,7 +173,7 @@ class SyncMessage implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, arguments: [timestamp]);
+    return OSCMessage(address.value, [timestamp]);
   }
 
   static SyncMessage? fromOsc(OSCMessage message) {


### PR DESCRIPTION
## Summary
- update OSC message creation API to match the package's constructor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686db604effc8332b0c30f05b890e8d2