### PR TITLE
Update iOS deployment target

### DIFF
--- a/flashlights_client/ios/Podfile
+++ b/flashlights_client/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -39,6 +39,13 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+  end
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'
+      end
+    end
   end
   # Ensure embedded frameworks are ad-hoc signed (avoid invalid identity errors)
   require 'xcodeproj'


### PR DESCRIPTION
## Summary
- raise iOS deployment target in Podfile
- set `IPHONEOS_DEPLOYMENT_TARGET` for generated projects

## Testing
- `pod deintegrate` *(fails: command not found)*
- `pod install` *(fails: command not found)*
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter build ios --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de34ff9708332954902a9cb63c83b