### PR TITLE
Fix OSCMessage constructor usage

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -107,7 +107,7 @@ class OscListener {
   /// Broadcast a hello so servers can discover us
   void _sendHello() {
     if (_socket == null) return;
-    final msg = OSCMessage('/hello', [client.myIndex.value]);
+    final msg = OSCMessage('/hello', arguments: [client.myIndex.value]);
     _socket!.send(msg, InternetAddress('255.255.255.255'), 9000);
   }
 

--- a/flashlights_client/lib/network/osc_messages.dart
+++ b/flashlights_client/lib/network/osc_messages.dart
@@ -31,7 +31,7 @@ class FlashOn implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, [index, intensity]);
+    return OSCMessage(address.value, arguments: [index, intensity]);
   }
 
   static FlashOn? fromOsc(OSCMessage message) {
@@ -59,7 +59,7 @@ class FlashOff implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, [index]);
+    return OSCMessage(address.value, arguments: [index]);
   }
 
   static FlashOff? fromOsc(OSCMessage message) {
@@ -88,7 +88,7 @@ class AudioPlay implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, [index, file, gain]);
+    return OSCMessage(address.value, arguments: [index, file, gain]);
   }
 
   static AudioPlay? fromOsc(OSCMessage message) {
@@ -117,7 +117,7 @@ class AudioStop implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, [index]);
+    return OSCMessage(address.value, arguments: [index]);
   }
 
   static AudioStop? fromOsc(OSCMessage message) {
@@ -145,7 +145,7 @@ class MicRecord implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, [index, maxDuration]);
+    return OSCMessage(address.value, arguments: [index, maxDuration]);
   }
 
   static MicRecord? fromOsc(OSCMessage message) {
@@ -173,7 +173,7 @@ class SyncMessage implements OscCodable {
 
   @override
   OSCMessage toOsc() {
-    return OSCMessage(address.value, [timestamp]);
+    return OSCMessage(address.value, arguments: [timestamp]);
   }
 
   static SyncMessage? fromOsc(OSCMessage message) {


### PR DESCRIPTION
## Summary
- update usage of `OSCMessage` to use the named `arguments` parameter

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de5d5efb48332b7f41dd13f099eff