### PR TITLE
Ensure sequential OSC message handling

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -37,7 +37,9 @@ class OscListener {
       // Best effort; not all implementations expose the inner socket.
     }
     // Listen and dispatch using the current slot
-    await _socket!.listen((OSCMessage msg) => _dispatch(msg));
+    await _socket!.listen((OSCMessage msg) async {
+      await _dispatch(msg);
+    });
 
     // Periodically announce our presence so the server can discover us.
     _helloTimer = async.Timer.periodic(


### PR DESCRIPTION
## Summary
- listen for OSC messages with an `async` callback so each `_dispatch` call completes before processing the next message

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebeb221a08332ae24458768e49f7c