### PR TITLE
Implement /sync clock offset handling

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -107,11 +107,33 @@ class OscListener {
         break;
 
       case '/sync':
+        _markConnected();
+        if (m.arguments.isNotEmpty) {
+          final ts = m.arguments[0];
+          BigInt? ntp;
+          if (ts is BigInt) {
+            ntp = ts;
+          } else if (ts is int) {
+            ntp = BigInt.from(ts);
+          }
+          if (ntp != null) {
+            const eraOffset = 2208988800; // Seconds between 1900 and 1970
+            final serverSecs = ntp - BigInt.from(eraOffset);
+            final serverMs = serverSecs.toInt() * 1000;
+            final localMs = DateTime.now().millisecondsSinceEpoch;
+            final offset = serverMs - localMs;
+            client.clockOffsetMs =
+                (client.clockOffsetMs + offset) / 2; // simple smoothing
+            print('[OSC] Clock offset updated to ${client.clockOffsetMs} ms');
+          }
+        }
+        break;
+
       case '/hello':
         _markConnected();
         break;
 
-      // TODO: implement /mic/record and /sync handling.
+      // TODO: implement /mic/record handling.
     }
   }
 


### PR DESCRIPTION
## Summary
- compute clock offset when receiving `/sync`
- keep debug print for clock offset updates
- update TODO comment

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec1f1d2f483329b382c1d867f45f0