### PR TITLE
Add mic record OSC handling

### DIFF
--- a/flashlights_client/lib/model/client_state.dart
+++ b/flashlights_client/lib/model/client_state.dart
@@ -8,7 +8,8 @@ class ClientState {
       ),
       clockOffsetMs = 0.0,
       flashOn = ValueNotifier<bool>(false),
-      audioPlaying = ValueNotifier<bool>(false);
+      audioPlaying = ValueNotifier<bool>(false),
+      recording = ValueNotifier<bool>(false);
 
   /// Singer slot (1-32). Notifier so UI can react to changes at runtime.
   final ValueNotifier<int> myIndex;
@@ -21,6 +22,9 @@ class ClientState {
 
   /// Whether audio is currently playing.
   final ValueNotifier<bool> audioPlaying;
+
+  /// Whether the microphone is currently recording.
+  final ValueNotifier<bool> recording;
 
   /// Whether the client is connected to the server.
   final ValueNotifier<bool> connected = ValueNotifier<bool>(false);

--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -6,6 +6,7 @@ import 'package:osc/osc.dart';
 // Import client state to update slot dynamically
 import '../model/client_state.dart';
 import 'package:torch_light/torch_light.dart';
+import 'package:mic_stream/mic_stream.dart';
 
 /// Singleton OSC listener for flash/audio/mic/sync cues.
 class OscListener {
@@ -15,6 +16,7 @@ class OscListener {
   OSCSocket? _socket;
   async.Timer? _helloTimer;
   late final AudioPlayer _player = AudioPlayer();
+  async.StreamSubscription<List<int>>? _micSubscription;
   bool _running = false;
   async.Timer? _disconnectTimer;
 
@@ -133,7 +135,32 @@ class OscListener {
         _markConnected();
         break;
 
-      // TODO: implement /mic/record handling.
+      case '/mic/record':
+        final id = m.arguments[0] as int;
+        final durationSec = (m.arguments[1] as num).toDouble();
+        if (id == myIndex) {
+          print('[OSC] Starting mic recording for $durationSec s');
+          await MicStream.shouldRequestPermission(true);
+          final audioStream = MicStream.microphone(
+            audioSource: AudioSource.DEFAULT,
+            sampleRate: 44100,
+            channelConfig: ChannelConfig.CHANNEL_IN_MONO,
+            audioFormat: AudioFormat.ENCODING_PCM_16BIT,
+          );
+          _micSubscription?.cancel();
+          _micSubscription = audioStream.listen((_) {});
+          client.recording.value = true;
+          async.Timer(
+            Duration(milliseconds: (durationSec * 1000).toInt()),
+            () async {
+              await _micSubscription?.cancel();
+              _micSubscription = null;
+              client.recording.value = false;
+              print('[OSC] Mic recording of $durationSec s completed');
+            },
+          );
+        }
+        break;
     }
   }
 
@@ -163,10 +190,12 @@ class OscListener {
   Future<void> stop() async {
     _socket?.close();
     _socket = null;
+    await _micSubscription?.cancel();
+    _micSubscription = null;
+    client.recording.value = false;
     await _player.dispose();
     _running = false;
     _disconnectTimer?.cancel();
     _helloTimer?.cancel();
     client.connected.value = false;
-    print('[OSC] Listener stopped');
-  }}
+    print('[OSC] Listener stopped');  }}


### PR DESCRIPTION
## Summary
- support microphone recording command
- track recording state in `ClientState`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2c2e7408332b2bb197df7bc9e88