### PR TITLE
Update iOS Info.plist for local network usage

### DIFF
--- a/flashlights_client/ios/Runner/Info.plist
+++ b/flashlights_client/ios/Runner/Info.plist
@@ -55,6 +55,8 @@
 	<!-- Microphone permission (syncs devices via audio beacons) -->
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Needed so Flashlights-in-the-Dark can listen for sync cues and keep the choir in time.</string>
+        <key>NSLocalNetworkUsageDescription</key>
+        <string>Allows Flashlights Client to discover the server over the local network.</string>
 
 	<!-- Keep audio session alive while app is in the background -->
 	<key>UIBackgroundModes</key>


### PR DESCRIPTION
## Summary
- add `NSLocalNetworkUsageDescription` to Runner Info.plist so the app can discover the server on the local network

## Testing
- `python3 - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('flashlights_client/ios/Runner/Info.plist')
print("XML OK")
PY`

------
https://chatgpt.com/codex/tasks/task_e_686ee53a6a4c83329b5248cb5442c55f