### PR TITLE
Uncomment platform setting in Podfile

### DIFF
--- a/flashlights_client/ios/Podfile
+++ b/flashlights_client/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
## Summary
- enable global platform for iOS pods and set it to 12.0

## Testing
- `pod install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee53c2ff083328b71684e60e790ee