### PR TITLE
Wrap torch calls with error handling

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -60,15 +60,25 @@ class OscListener {
         final id = m.arguments[0] as int;
         // Intensity argument is ignored – torch_light has no such API.
         if (id == myIndex) {
-          client.flashOn.value = true;
-          await TorchLight.enableTorch();
+          try {
+            await TorchLight.enableTorch();
+            client.flashOn.value = true;
+          } catch (e) {
+            print('[OSC] Torch error: $e');
+            client.flashOn.value = false;
+          }
         }
         break;
 
       case '/flash/off':
         if (m.arguments[0] as int == myIndex) {
-          client.flashOn.value = false;
-          await TorchLight.disableTorch();
+          try {
+            await TorchLight.disableTorch();
+            client.flashOn.value = false;
+          } catch (e) {
+            print('[OSC] Torch error: $e');
+            client.flashOn.value = true;
+          }
         }
         break;
 


### PR DESCRIPTION
## Summary
- handle errors from `TorchLight.enableTorch()` and `disableTorch()` in `osc_listener.dart`
- ensure `flashOn` value reflects the real torch state and log failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee53ea94c8332b9ec505de97619d3