### PR TITLE
Fix widget test using FlashlightsApp

### DIFF
--- a/flashlights_client/test/widget_test.dart
+++ b/flashlights_client/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:flashlights_client/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const FlashlightsApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- update widget test to use the `FlashlightsApp` widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee53fdcec8332a990df60ee36f941