### PR TITLE
Fix final braces newline in OscListener

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -192,5 +192,6 @@ class OscListener {
     _running = false;
     _disconnectTimer?.cancel();
     _helloTimer?.cancel();
-    client.connected.value = false;
-    print('[OSC] Listener stopped');  }}
+    client.connected.value = false;    print('[OSC] Listener stopped');
+  }
+}


### PR DESCRIPTION
## Summary
- ensure closing braces of `OscListener` end on separate lines

## Testing
- `dart format flashlights_client/lib/network/osc_listener.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee541d1b883328087d9cf2c190782