### PR TITLE
fix(iOS): Repair Runner.xcodeproj parse-error after merge

### DIFF
--- a/flashlights_client/ios/Runner.xcodeproj/project.pbxproj
+++ b/flashlights_client/ios/Runner.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = $(DEVELOPMENT_TEAM);
+                               DEVELOPMENT_TEAM = 3J9NVMRPVQ;
 				ENABLE_BITCODE = NO;
 				EXPANDED_CODE_SIGN_IDENTITY = "-";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -496,7 +496,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.keex.Flashlights-ITD-Client";
+                               PRODUCT_BUNDLE_IDENTIFIER = com.simphoni.flashlights;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -512,7 +512,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = $(DEVELOPMENT_TEAM);
+                               DEVELOPMENT_TEAM = 3J9NVMRPVQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.keex.Flashlights-ITD-Client.RunnerTests";
@@ -532,7 +532,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = $(DEVELOPMENT_TEAM);
+                               DEVELOPMENT_TEAM = 3J9NVMRPVQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.keex.Flashlights-ITD-Client.RunnerTests";
@@ -550,7 +550,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = $(DEVELOPMENT_TEAM);
+                               DEVELOPMENT_TEAM = 3J9NVMRPVQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.keex.Flashlights-ITD-Client.RunnerTests";
@@ -678,7 +678,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = $(DEVELOPMENT_TEAM);
+                               DEVELOPMENT_TEAM = 3J9NVMRPVQ;
 				ENABLE_BITCODE = NO;
 				EXPANDED_CODE_SIGN_IDENTITY = "-";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -686,7 +686,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.keex.Flashlights-ITD-Client";
+                               PRODUCT_BUNDLE_IDENTIFIER = com.simphoni.flashlights;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -702,7 +702,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = $(DEVELOPMENT_TEAM);
+                               DEVELOPMENT_TEAM = 3J9NVMRPVQ;
 				ENABLE_BITCODE = NO;
 				EXPANDED_CODE_SIGN_IDENTITY = "-";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -710,7 +710,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.keex.Flashlights-ITD-Client";
+                               PRODUCT_BUNDLE_IDENTIFIER = com.simphoni.flashlights;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Summary
- fix Runner.xcodeproj parse errors by removing invalid values
- set `DEVELOPMENT_TEAM` to `3J9NVMRPVQ`
- set `PRODUCT_BUNDLE_IDENTIFIER` to `com.simphoni.flashlights`

## Testing
- `plutil -lint -- ios/Runner.xcodeproj/project.pbxproj`
- `xcodebuild -project ios/Runner.xcodeproj -list` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686eea4526dc83328ce13a23cb7c1ba5