### PR TITLE
Fix async prefix build error

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -38,7 +38,7 @@ class OscListener {
   OSCSocket? _socket;
   Timer? _helloTimer;
   late final AudioPlayer _player = AudioPlayer();
-  async.StreamSubscription<List<int>>? _micSubscription;
+  StreamSubscription<List<int>>? _micSubscription;
   bool _running = false;
   Timer? _disconnectTimer;
 
@@ -173,7 +173,7 @@ class OscListener {
           _micSubscription?.cancel();
           _micSubscription = audioStream.listen((_) {});
           client.recording.value = true;
-          async.Timer(
+          Timer(
             Duration(milliseconds: (durationSec * 1000).toInt()),
             () async {
               await _micSubscription?.cancel();


### PR DESCRIPTION
## Summary
- remove incorrect `async.` prefix for StreamSubscription and Timer in OSC listener

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eef38998c833290a39af3d8aa7718