### PR TITLE
Fix hello handler slot emission

### DIFF
--- a/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
@@ -191,10 +191,11 @@ final class HelloDatagramHandler: ChannelInboundHandler {
         guard let bytes = buffer.readBytes(length: buffer.readableBytes) else {
             return
         }
-        // only emit if we have an IP to send to
-        if let ip = env.remoteAddress?.ipAddress {
-            Task {
-                let slot = await owner.parseHelloSlot(bytes)
+        // Only emit if both an IP address and a valid slot are found
+        guard let ip = env.remoteAddress.ipAddress else { return }
+
+        Task {
+            if let slot = await owner.parseHelloSlot(bytes) {
                 await owner.emitHello(slot: slot, ip: ip)
             }
         }


### PR DESCRIPTION
## Summary
- guard for non-optional remoteAddress
- only emit hello when parseHelloSlot returns a slot

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_687058fd607c8332aecf60d3844da99f