### PR TITLE
Fix OscBroadcaster init sequence

### DIFF
--- a/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
@@ -68,10 +68,15 @@ public actor OscBroadcaster {
             .bind(host: "0.0.0.0", port: port)
             .get()
 
-        // Listen for client /hello announcements
-        try await self.channel.pipeline.addHandler(HelloDatagramHandler(owner: self))
-
+        // Initialise **all** stored properties *before* we capture `self`
+        // inside any pipeline handler, otherwise Swift’s definite-initialisation
+        // rules complain that “self is used before all stored properties
+        // are initialised”.
         self.broadcastAddrs = OscBroadcaster.gatherBroadcastAddrs(port: port)
+
+        // Now that every property is set, it’s safe to reference `self`.
+        try await self.channel.pipeline
+            .addHandler(HelloDatagramHandler(owner: self))
 
         print("UDP broadcaster ready on 0.0.0.0:\(port) ✅")
     }


### PR DESCRIPTION
## Summary
- ensure broadcastAddrs is initialised before adding hello handler

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870663b47dc8332a6e4413f5db4e89b