### PR TITLE
Fix broadcast socket options and update OSC send API

### DIFF
--- a/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
@@ -61,6 +61,7 @@ public actor OscBroadcaster {
         // Datagram bootstrap with broadcast privileges.
         let bootstrap = DatagramBootstrap(group: eventLoopGroup)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseport), value: 1)
             .channelOption(ChannelOptions.socketOption(.so_broadcast), value: 1)
 
         // Bind to *all* interfaces on the chosen port.

--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -213,7 +213,7 @@ class OscListener {
             parts[3] = '255';
             final bcast = InternetAddress(parts.join('.'));
             try {
-              _socket!.send(msg, destination: bcast, port: 9000);
+              _socket!.send(msg, address: bcast, port: 9000);
             } catch (_) {
               // ignore failures
             }


### PR DESCRIPTION
## Summary
- allow port reuse on macOS OSC broadcaster
- adjust OSC send call for new API

## Testing
- `swift --version`
- `swift build` *(fails: no Package.swift)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707a2b23b0833284ed512a453f9e51