### PR TITLE
Fix OSC send arguments

### DIFF
--- a/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscBroadcaster.swift
@@ -7,10 +7,14 @@
 
 import Foundation
 import NIOCore
+#if os(Linux) || os(Android)
+import Glibc
+#else
+import Darwin
+#endif
 import NIOPosix
 import OSCKit          // OSCMessage, OSCAddressPattern
 import SystemConfiguration
-import Darwin
 
 /// Broadcasts OSC messages over UDP to all detected local-network broadcast
 /// addresses. Designed for lightweight one-way cues.
@@ -61,7 +65,7 @@ public actor OscBroadcaster {
         // Datagram bootstrap with broadcast privileges.
         let bootstrap = DatagramBootstrap(group: eventLoopGroup)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .channelOption(ChannelOptions.socketOption(.so_reuseport), value: 1)
+            .channelOption(ChannelOptions.socket(SOL_SOCKET, SO_REUSEPORT), value: 1)
             .channelOption(ChannelOptions.socketOption(.so_broadcast), value: 1)
 
         // Bind to *all* interfaces on the chosen port.

--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -213,7 +213,11 @@ class OscListener {
             parts[3] = '255';
             final bcast = InternetAddress(parts.join('.'));
             try {
-              _socket!.send(msg, address: bcast, port: 9000);
+              _socket!.send(
+                msg,
+                address: bcast,
+                port: 9000,
+              );
             } catch (_) {
               // ignore failures
             }

--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -12,14 +12,10 @@ import 'package:mic_stream/mic_stream.dart' as mic;
 OSCSocket _createBroadcastSocket({
   required InternetAddress serverAddress,
   required int serverPort,
-  required InternetAddress destination,
-  required int destinationPort,
 }) {
   final socket = OSCSocket(
     serverAddress: serverAddress,
     serverPort: serverPort,
-    destination: destination,
-    destinationPort: destinationPort,
   );
   // Enable UDP broadcast if the underlying OSCSocket exposes a raw socket.
   try {
@@ -55,12 +51,10 @@ class OscListener {
     if (_running) return;
     _running = true;
 
-    _socket = _createBroadcastSocket(
-      serverAddress: InternetAddress.anyIPv4,
-      serverPort: 9000,
-      destination: InternetAddress('255.255.255.255'),
-      destinationPort: 9000,
-    );
+  _socket = _createBroadcastSocket(
+    serverAddress: InternetAddress.anyIPv4,
+    serverPort: 9000,
+  );
     // Listen and dispatch using the current slot
     await _socket!.listen((OSCMessage msg) async {
       await _dispatch(msg);
@@ -200,7 +194,11 @@ class OscListener {
     if (_socket == null) return;
     final msg = OSCMessage('/hello', arguments: [client.myIndex.value]);
     // Always send via the default broadcast address
-    _socket!.send(msg);
+    _socket!.send(
+      msg,
+      address: InternetAddress('255.255.255.255'),
+      port: 9000,
+    );
 
     // Additionally attempt per-interface broadcasts for networks where
     // 255.255.255.255 is filtered.  Best effort only; errors are ignored.


### PR DESCRIPTION
## Summary
- correct parameter names for OSCSocket.send when broadcasting

## Testing
- `swift --version`
- `dart --version` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687099371fe083329708b730125195a5