### PR TITLE
Fix OSC argument type and add export compliance flags

### DIFF
--- a/flashlights_client/ios/Runner/Info.plist
+++ b/flashlights_client/ios/Runner/Info.plist
@@ -64,9 +64,13 @@
 
 	<!-- Keep audio session alive while app is in the background -->
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
+        <array>
+                <string>audio</string>
+        </array>
+
+        <!-- Declare that this app does not use non-exempt encryption -->
+        <key>ITSAppUsesNonExemptEncryption</key>
+        <false/>
 
 </dict>
 </plist>

--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -141,7 +141,9 @@ class OscListener {
           return null; // unsupported
       }
     }
-    return OSCMessage(address, arguments: args);
+    // Explicitly cast the dynamic list to the non-nullable
+    // type expected by the OSCMessage constructor.
+    return OSCMessage(address, arguments: List<Object>.from(args));
   }
 
   /* -------------------------------------------------------------------- */

--- a/flashlights_client/macos/Runner/Info.plist
+++ b/flashlights_client/macos/Runner/Info.plist
@@ -26,7 +26,11 @@
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+        <key>NSPrincipalClass</key>
+        <string>NSApplication</string>
+
+        <!-- Declare that this app does not use non-exempt encryption -->
+        <key>ITSAppUsesNonExemptEncryption</key>
+        <false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- avoid dynamic -> Object list mismatch in OSC listener
- declare no non-exempt encryption in iOS/macOS Info.plist files

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870cf272c48833289617d39e2e6a992