### PR TITLE
Fix export compliance for macOS app

### DIFF
--- a/FlashlightsInTheDark.xcodeproj/project.pbxproj
+++ b/FlashlightsInTheDark.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
                                GENERATE_INFOPLIST_FILE = YES;
                                INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
                                INFOPLIST_KEY_NSHumanReadableCopyright = "";
+                               INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -484,6 +485,7 @@
                                GENERATE_INFOPLIST_FILE = YES;
                                INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
                                INFOPLIST_KEY_NSHumanReadableCopyright = "";
+                               INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",


### PR DESCRIPTION
## Summary
- configure Xcode build settings to declare non-exempt encryption

## Testing
- `pytest -q`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871657bf8548332863eb8aef5a92352