### PR TITLE
Fix slot color mapping

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -28,8 +28,8 @@ struct ComposerConsoleView: View {
 
     private let slotOutlineColors: [Int: Color] = [
         27: .royalBlue, 41: .royalBlue, 42: .royalBlue,
-        1: .brightRed, 15: .brightRed, 16: .brightRed,
-        29: .slotGreen, 44: .slotGreen,
+        1: .brightRed, 14: .brightRed, 15: .brightRed,
+        16: .slotGreen, 29: .slotGreen, 44: .slotGreen,
         3: .slotPurple, 4: .slotPurple, 18: .slotPurple,
         7: .slotYellow, 19: .slotYellow, 34: .slotYellow,
         9: .lightRose, 20: .lightRose, 21: .lightRose,


### PR DESCRIPTION
## Summary
- assign red border to slots 1, 14, and 15
- assign green border to slots 16, 29, and 44

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718acb37848332b7dcb44b11180fc2