### PR TITLE
Align keyboard slot mappings

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -33,72 +33,73 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 return nil
             }
-            // Map rows 1-4 & cols A-H, deriving slot and MIDI note
-            let rows = ["12345678", "qwertyui", "asdfghjk", "zxcvbnm,"]
-            for (r, row) in rows.enumerated() {
-                if let idx = row.firstIndex(of: c) {
-                    let col = row.distance(from: row.startIndex, to: idx)
-                    let slot = r * 8 + col
-                    let isDown = (event.type == .keyDown)
-                    if isDown {
-                        // ignore repeats
-                        if self.heldSlots.contains(slot) { return nil }
-                        self.heldSlots.insert(slot)
+            // Mapping from keyboard key to real slot number
+            let keyToSlot: [Character: Int] = [
+                "2": 1, "3": 3, "4": 4, "5": 5, "u": 7, "7": 9, "9": 12,
+                "q": 14, "w": 15, "d": 16, "e": 18, "r": 19, "k": 20, "i": 21,
+                "8": 23, "o": 24, "p": 25, "a": 27, "s": 29, "j": 34, "l": 38,
+                ";": 40, "x": 41, "c": 42, "v": 44, "m": 51, ",": 53, ".": 54
+            ]
+            if let slot = keyToSlot[c] {
+                let isDown = (event.type == .keyDown)
+                if isDown {
+                    // ignore repeats
+                    if self.heldSlots.contains(slot) { return nil }
+                    self.heldSlots.insert(slot)
+                    self.sustainedSlots.remove(slot)
+                    // trigger flash and/or sound
+                    switch self.state.keyboardTriggerMode {
+                    case .torch:
+                        self.state.flashOn(id: slot)
+                    case .sound:
+                        guard slot < self.state.devices.count else { return nil }
+                        let device = self.state.devices[slot]
+                        self.state.triggerSound(device: device)
+                    case .both:
+                        self.state.flashOn(id: slot)
+                        guard slot < self.state.devices.count else { return nil }
+                        let deviceBoth = self.state.devices[slot]
+                        self.state.triggerSound(device: deviceBoth)
+                    }
+                    // send MIDI note on with scale mapping
+                    let r = slot / 8
+                    let col = slot % 8
+                    let octaveOffset = UInt8(r * 12)
+                    let offset = self.noteOffsets[col]
+                    let noteOn = self.baseNote + octaveOffset + offset
+                    self.midi.sendNoteOn(noteOn)
+                } else {
+                    // key up: handle sustain
+                    if self.sustainOn {
+                        self.heldSlots.remove(slot)
+                        self.sustainedSlots.insert(slot)
+                    } else {
+                        self.heldSlots.remove(slot)
                         self.sustainedSlots.remove(slot)
-                        // trigger flash and/or sound
+                        // release flash and/or sound
                         switch self.state.keyboardTriggerMode {
                         case .torch:
-                            self.state.flashOn(id: slot)
+                            self.state.flashOff(id: slot)
                         case .sound:
                             guard slot < self.state.devices.count else { return nil }
                             let device = self.state.devices[slot]
-                            self.state.triggerSound(device: device)
+                            self.state.stopSound(device: device)
                         case .both:
-                            self.state.flashOn(id: slot)
+                            self.state.flashOff(id: slot)
                             guard slot < self.state.devices.count else { return nil }
-                            let deviceBoth = self.state.devices[slot]
-                            self.state.triggerSound(device: deviceBoth)
-                        default:
-                            break
+                            let deviceBothRel = self.state.devices[slot]
+                            self.state.stopSound(device: deviceBothRel)
                         }
-                        // send MIDI note on with scale mapping
+                        // send MIDI note off with mapping
+                        let r = slot / 8
+                        let col = slot % 8
                         let octaveOffset = UInt8(r * 12)
                         let offset = self.noteOffsets[col]
-                        let noteOn = self.baseNote + octaveOffset + offset
-                        self.midi.sendNoteOn(noteOn)
-                    } else {
-                        // key up: handle sustain
-                        if self.sustainOn {
-                            self.heldSlots.remove(slot)
-                            self.sustainedSlots.insert(slot)
-                        } else {
-                            self.heldSlots.remove(slot)
-                            self.sustainedSlots.remove(slot)
-                            // release flash and/or sound
-                            switch self.state.keyboardTriggerMode {
-                            case .torch:
-                                self.state.flashOff(id: slot)
-                            case .sound:
-                                guard slot < self.state.devices.count else { return nil }
-                                let device = self.state.devices[slot]
-                                self.state.stopSound(device: device)
-                            case .both:
-                                self.state.flashOff(id: slot)
-                                guard slot < self.state.devices.count else { return nil }
-                                let deviceBothRel = self.state.devices[slot]
-                                self.state.stopSound(device: deviceBothRel)
-                            default:
-                                break
-                            }
-                            // send MIDI note off with mapping
-                            let octaveOffset = UInt8(r * 12)
-                            let offset = self.noteOffsets[col]
-                            let noteOff = self.baseNote + octaveOffset + offset
-                            self.midi.sendNoteOff(noteOff)
-                        }
+                        let noteOff = self.baseNote + octaveOffset + offset
+                        self.midi.sendNoteOff(noteOff)
                     }
-                    return nil
                 }
+                return nil
             }
             // Spacebar for sustain pedal
             if event.keyCode == 49 { // space

--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -338,8 +338,8 @@ self) { row in
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(Color.clear, lineWidth: 0)
-                            .shadow(color: isTriggered ? Color.white.opacity(0.95) : .clear,
-                                    radius: isTriggered ? 36 : 0)
+                            .shadow(color: (isTriggered || device.torchOn) ? Color.white.opacity(0.95) : .clear,
+                                    radius: (isTriggered || device.torchOn) ? 36 : 0)
                     )
                 }
             }

--- a/Flashlights_Midi_Panel_Simulator.py
+++ b/Flashlights_Midi_Panel_Simulator.py
@@ -41,7 +41,7 @@ QueueItem = Union[Tuple[int, bool], str, Tuple[str, str]]
 class Config:
     rows: int = 4
     cols: int = 8
-    key_rows: Tuple[str, ...] = ("12345678", "qwertyui", "asdfghjk", "zxcvbnm,")
+    key_rows: Tuple[str, ...] = ()  # unused
     note_offsets: Tuple[int, ...] = (0, 1, 3, 4, 7, 8, 10, 11)
     base_note: int = 36
     all_note: int = 84
@@ -66,9 +66,12 @@ class Config:
              for r in range(self.rows) for c, off in enumerate(self.note_offsets)})
         object.__setattr__(self, "slot_to_note",
             {v: k for k, v in self.note_to_slot.items()})
-        object.__setattr__(self, "key_to_slot",
-            {ch: r*self.cols + c for r, row in enumerate(self.key_rows)
-             for c, ch in enumerate(row)})
+        object.__setattr__(self, "key_to_slot", {
+            "2": 1, "3": 3, "4": 4, "5": 5, "u": 7, "7": 9, "9": 12,
+            "q": 14, "w": 15, "d": 16, "e": 18, "r": 19, "k": 20, "i": 21,
+            "8": 23, "o": 24, "p": 25, "a": 27, "s": 29, "j": 34, "l": 38,
+            ";": 40, "x": 41, "c": 42, "v": 44, "m": 51, ",": 53, ".": 54
+        })
 
 CFG = Config()
 
@@ -423,7 +426,7 @@ class App(tk.Tk):
         spin(self.release_var, 5000).grid(row=0, column=7, padx=2)
 
         tk.Label(self,
-                 text="Typing rows: " + " ".join(CFG.key_rows) +
+                 text="Typing keys: " + " ".join(sorted(CFG.key_to_slot.keys())) +
                       "   (SPACE = sustain, 0 = ALL w/ADSR)",
                  fg="#bbbbbb", bg=CFG.bg).pack()
 


### PR DESCRIPTION
## Summary
- update AppDelegate mapping for key-press slots
- glow slots while torch is active
- adjust Midi panel simulator to use same keyboard layout

## Testing
- `python3 -m py_compile Flashlights_Midi_Panel_Simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_68718a28c9a083328589347dbf00f147