### PR TITLE
Add ComposerConsole triple-trigger buttons and fix keyboard events

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -15,6 +15,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var heldSlots: Set<Int> = []
     /// Slots held beyond key release due to sustain
     private var sustainedSlots: Set<Int> = []
+    /// Function key mapping (F1-F9 -> triple trigger group)
+    private let fKeyToGroup: [UInt16: Int] = [
+        122: 1, // F1
+        120: 2, // F2
+        99: 3,  // F3
+        118: 4, // F4
+        96: 5,  // F5
+        97: 6,  // F6
+        98: 7,  // F7
+        100: 8, // F8
+        101: 9  // F9
+    ]
+
+    private let groupSlots: [Int: [Int]] = [
+        1: [27, 41, 42],
+        2: [1, 14, 15],
+        3: [16, 29, 44],
+        4: [3, 4, 18],
+        5: [7, 19, 34],
+        6: [9, 20, 21],
+        7: [23, 38, 51],
+        8: [12, 24, 25],
+        9: [40, 53, 54]
+    ]
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp]) { [weak self] event in
@@ -22,6 +46,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // SAFETY: unwrap self once, then ALWAYS use `self.` inside
             // -------------------------------------------------------------
             guard let self = self else { return event }
+            if let group = self.fKeyToGroup[event.keyCode], event.type == .keyDown {
+                if let slots = self.groupSlots[group] {
+                    self.state.triggerSlots(realSlots: slots)
+                }
+                return nil
+            }
             guard let chars = event.charactersIgnoringModifiers?.lowercased(),
                   let c = chars.first else { return event }
             // Envelope trigger on “0” key (ADSR all lamps)
@@ -41,29 +71,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 ";": 40, "x": 41, "c": 42, "v": 44, "m": 51, ",": 53, ".": 54
             ]
             if let slot = keyToSlot[c] {
+                let idx = slot - 1
                 let isDown = (event.type == .keyDown)
                 if isDown {
                     // ignore repeats
-                    if self.heldSlots.contains(slot) { return nil }
-                    self.heldSlots.insert(slot)
-                    self.sustainedSlots.remove(slot)
+                    if self.heldSlots.contains(idx) { return nil }
+                    self.heldSlots.insert(idx)
+                    self.sustainedSlots.remove(idx)
                     // trigger flash and/or sound
                     switch self.state.keyboardTriggerMode {
                     case .torch:
-                        self.state.flashOn(id: slot)
+                        self.state.flashOn(id: idx)
                     case .sound:
-                        guard slot < self.state.devices.count else { return nil }
-                        let device = self.state.devices[slot]
+                        guard idx < self.state.devices.count else { return nil }
+                        let device = self.state.devices[idx]
                         self.state.triggerSound(device: device)
                     case .both:
-                        self.state.flashOn(id: slot)
-                        guard slot < self.state.devices.count else { return nil }
-                        let deviceBoth = self.state.devices[slot]
+                        self.state.flashOn(id: idx)
+                        guard idx < self.state.devices.count else { return nil }
+                        let deviceBoth = self.state.devices[idx]
                         self.state.triggerSound(device: deviceBoth)
                     }
                     // send MIDI note on with scale mapping
-                    let r = slot / 8
-                    let col = slot % 8
+                    let r = idx / 8
+                    let col = idx % 8
                     let octaveOffset = UInt8(r * 12)
                     let offset = self.noteOffsets[col]
                     let noteOn = self.baseNote + octaveOffset + offset
@@ -71,28 +102,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     // key up: handle sustain
                     if self.sustainOn {
-                        self.heldSlots.remove(slot)
-                        self.sustainedSlots.insert(slot)
+                        self.heldSlots.remove(idx)
+                        self.sustainedSlots.insert(idx)
                     } else {
-                        self.heldSlots.remove(slot)
-                        self.sustainedSlots.remove(slot)
+                        self.heldSlots.remove(idx)
+                        self.sustainedSlots.remove(idx)
                         // release flash and/or sound
                         switch self.state.keyboardTriggerMode {
                         case .torch:
-                            self.state.flashOff(id: slot)
+                            self.state.flashOff(id: idx)
                         case .sound:
-                            guard slot < self.state.devices.count else { return nil }
-                            let device = self.state.devices[slot]
+                            guard idx < self.state.devices.count else { return nil }
+                            let device = self.state.devices[idx]
                             self.state.stopSound(device: device)
                         case .both:
-                            self.state.flashOff(id: slot)
-                            guard slot < self.state.devices.count else { return nil }
-                            let deviceBothRel = self.state.devices[slot]
+                            self.state.flashOff(id: idx)
+                            guard idx < self.state.devices.count else { return nil }
+                            let deviceBothRel = self.state.devices[idx]
                             self.state.stopSound(device: deviceBothRel)
                         }
                         // send MIDI note off with mapping
-                        let r = slot / 8
-                        let col = slot % 8
+                        let r = idx / 8
+                        let col = idx % 8
                         let octaveOffset = UInt8(r * 12)
                         let offset = self.noteOffsets[col]
                         let noteOff = self.baseNote + octaveOffset + offset

--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -38,6 +38,30 @@ struct ComposerConsoleView: View {
         40: .skyBlue, 53: .skyBlue, 54: .skyBlue,
         5: .white
     ]
+
+    private let tripleTriggers: [Int: [Int]] = [
+        1: [27, 41, 42],
+        2: [1, 14, 15],
+        3: [16, 29, 44],
+        4: [3, 4, 18],
+        5: [7, 19, 34],
+        6: [9, 20, 21],
+        7: [23, 38, 51],
+        8: [12, 24, 25],
+        9: [40, 53, 54]
+    ]
+
+    private let tripleColors: [Int: Color] = [
+        1: .royalBlue,
+        2: .brightRed,
+        3: .slotGreen,
+        4: .slotPurple,
+        5: .slotYellow,
+        6: .lightRose,
+        7: .slotOrange,
+        8: .hotMagenta,
+        9: .skyBlue
+    ]
     
     @State private var leftPanelWidth: CGFloat = 300
     var body: some View {
@@ -186,6 +210,19 @@ self) { row in
                             .frame(maxWidth: .infinity)
                         }
                     }
+                    HStack(spacing: 12) {
+                        ForEach(1...9, id: \.
+self) { idx in
+                            Button("C3-\(idx)") {
+                                if let slots = tripleTriggers[idx] {
+                                    state.triggerSlots(realSlots: slots)
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(tripleColors[idx] ?? .white)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
                     Spacer(minLength: 8)
                     // Status bar
                     Text(state.lastLog)

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -143,6 +143,26 @@ public final class ConsoleState: ObservableObject, Sendable {
             midi.sendControlChange(UInt8(id + 1), value: 0)
         }
     }
+
+    /// Trigger a list of real slots according to the current keyboardTriggerMode.
+    public func triggerSlots(realSlots: [Int]) {
+        for real in realSlots {
+            let idx = real - 1
+            switch keyboardTriggerMode {
+            case .torch:
+                _ = toggleTorch(id: idx)
+            case .sound:
+                guard idx < devices.count else { continue }
+                let device = devices[idx]
+                triggerSound(device: device)
+            case .both:
+                _ = toggleTorch(id: idx)
+                guard idx < devices.count else { continue }
+                let device = devices[idx]
+                triggerSound(device: device)
+            }
+        }
+    }
     
     // MARK: – One-click build & run  🚀
     public func buildAndRun(device: ChoirDevice) {


### PR DESCRIPTION
## Summary
- add triple trigger button row in ComposerConsoleView
- implement `triggerSlots` helper in `ConsoleState`
- correct keyboard slot index mapping in `AppDelegate`
- support F1–F9 keys to fire triple-trigger groups

## Testing
- `swift test -v` *(fails: Package.swift missing)*
- `xcodebuild -list` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68718f0fcd488332a32c76451212f01d