### PR TITLE
Keep MIDI note slot highlighted

### DIFF
--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -670,6 +670,8 @@ extension ConsoleState {
         let val = Int(note)
         if val >= 1 && val <= devices.count {
             let idx = val - 1
+            // Mark this slot as actively glowing while the MIDI note is held
+            glowingSlots.insert(val)
             switch keyboardTriggerMode {
             case .torch:
                 flashOn(id: idx)
@@ -693,6 +695,8 @@ extension ConsoleState {
         let val = Int(note)
         if val >= 1 && val <= devices.count {
             let idx = val - 1
+            // Clear the glow highlight when the MIDI note ends
+            glowingSlots.remove(val)
             switch keyboardTriggerMode {
             case .torch:
                 flashOff(id: idx)


### PR DESCRIPTION
## Summary
- show persistent glow on note-on and clear on note-off

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6871c51101548332bd2fd3f86145f878