### PR TITLE
Add mint flash screen overlay

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -62,8 +62,12 @@ struct ComposerConsoleView: View {
         8: .hotMagenta,
         9: .skyBlue
     ]
-    
+
     @State private var leftPanelWidth: CGFloat = 300
+    /// Returns true when any connected device's torch is currently on.
+    private var anyTorchOn: Bool {
+        state.devices.contains { $0.torchOn }
+    }
     var body: some View {
         ZStack {
             HStack(alignment: .top, spacing: 0) {
@@ -325,6 +329,15 @@ struct ComposerConsoleView: View {
                         height: (NSScreen.main?.visibleFrame.height ?? 768) * 0.8
                     )
                     .environmentObject(state)
+            }
+            // Full-screen flash overlay when any lamp is on
+            if anyTorchOn {
+                Color.mintGlow
+                    .opacity(0.8)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+                    .animation(.easeOut(duration: 0.3), value: anyTorchOn)
+                    .allowsHitTesting(false)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add computed property to check if any torch is lit
- overlay a mint-colored full-screen flash when any device is active

## Testing
- `swift test` *(fails: `Package.swift` not found)*
- `apt-get update` *(succeeds with some 403 errors)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68720378f0988332957bf628371c676a