### PR TITLE
Add persistent overlay tint

### DIFF
--- a/FlashlightsInTheDark_MacOS/Color+Theme.swift
+++ b/FlashlightsInTheDark_MacOS/Color+Theme.swift
@@ -17,4 +17,7 @@ extension Color {
     static let slotOrange = Color(red: 240/255, green: 81/255, blue: 0/255)
     static let hotMagenta = Color(red: 1.0, green: 0.0, blue: 215/255)
     static let skyBlue    = Color(red: 158/255, green: 228/255, blue: 1.0)
+
+    /// Always-on overlay color – dark purple/navy tint
+    static let purpleNavy = Color(red: 0.1, green: 0.0, blue: 0.2)
 }

--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -357,6 +357,12 @@ struct ComposerConsoleView: View {
                     .animation(.easeOut(duration: 0.3), value: anyTorchOn || strobeActive)
                     .allowsHitTesting(false)
             }
+            // Always-on purple/navy veil overlay
+            Color.purpleNavy
+                .opacity(0.5)
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+                .zIndex(1)
         }
     }
     


### PR DESCRIPTION
## Summary
- add a purple navy color to the theme
- overlay a semi-transparent veil on top of the console view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687207b74a7083329c7e7bac0dacea5f