### PR TITLE
Use mint accent for keyboard mode button

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -118,7 +118,7 @@ struct ComposerConsoleView: View {
                                 ZStack {
                                     Circle()
                                         .fill(state.keyboardTriggerMode == mode
-                                              ? Color.blue
+                                              ? Color.accentColor
                                               : Color.gray.opacity(0.3))
                                         .frame(width: 40, height: 40)
                                     // Icon for mode


### PR DESCRIPTION
## Summary
- use the system accent (mint) color for the active typing keyboard mode button

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_687215a08140833292f4833314f6ec49