### PR TITLE
Color-code singer slot in client

### DIFF
--- a/flashlights_client/lib/color_theme.dart
+++ b/flashlights_client/lib/color_theme.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// Slot outline colors matching the macOS console view.
+class SlotColors {
+  static const royalBlue = Color(0xFF0800F0);
+  static const brightRed = Color(0xFFF00800);
+  static const slotGreen = Color(0xFF29F000);
+  static const slotPurple = Color(0xFF6E00F0);
+  static const slotYellow = Color(0xFFF0AD00);
+  static const lightRose = Color(0xFFFFB8D9);
+  static const slotOrange = Color(0xFFF05100);
+  static const hotMagenta = Color(0xFFFF00D7);
+  static const skyBlue = Color(0xFF9EE4FF);
+}
+
+/// Mapping from real slot number to its outline color.
+const Map<int, Color> kSlotOutlineColors = {
+  27: SlotColors.royalBlue,
+  41: SlotColors.royalBlue,
+  42: SlotColors.royalBlue,
+  1: SlotColors.brightRed,
+  14: SlotColors.brightRed,
+  15: SlotColors.brightRed,
+  16: SlotColors.slotGreen,
+  29: SlotColors.slotGreen,
+  44: SlotColors.slotGreen,
+  3: SlotColors.slotPurple,
+  4: SlotColors.slotPurple,
+  18: SlotColors.slotPurple,
+  7: SlotColors.slotYellow,
+  19: SlotColors.slotYellow,
+  34: SlotColors.slotYellow,
+  9: SlotColors.lightRose,
+  20: SlotColors.lightRose,
+  21: SlotColors.lightRose,
+  23: SlotColors.slotOrange,
+  38: SlotColors.slotOrange,
+  51: SlotColors.slotOrange,
+  12: SlotColors.hotMagenta,
+  24: SlotColors.hotMagenta,
+  25: SlotColors.hotMagenta,
+  40: SlotColors.skyBlue,
+  53: SlotColors.skyBlue,
+  54: SlotColors.skyBlue,
+  5: Colors.white,
+};

--- a/flashlights_client/lib/main.dart
+++ b/flashlights_client/lib/main.dart
@@ -9,6 +9,7 @@ import 'network/osc_listener.dart';
 // import 'dart:convert';
 // removed discovery code
 import 'model/client_state.dart';
+import 'color_theme.dart';
 import 'version.dart';
 
 /// Native bootstrap that must finish **before** the widget tree is built.
@@ -114,10 +115,22 @@ class _BootstrapState extends State<Bootstrap> {
                     ValueListenableBuilder<int>(
                       valueListenable: client.myIndex,
                       builder: (context, myIndex, _) {
-                        return Text(
-                          'Singer #$myIndex',
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(fontSize: 20),
+                        final color = kSlotOutlineColors[myIndex];
+                        return Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 4, horizontal: 8),
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: color ?? Colors.transparent,
+                              width: 3,
+                            ),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            'Singer #$myIndex',
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(fontSize: 20),
+                          ),
                         );
                       },
                     ),


### PR DESCRIPTION
## Summary
- show slot-color border around `Singer #` indicator in the mobile client
- share slot colors with a new `color_theme.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68721715be2483328176c78b7c45c621