### PR TITLE
Adjust overlay opacity

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -367,7 +367,8 @@ struct ComposerConsoleView: View {
             }
             // Always-on purple/navy veil overlay
             Color.purpleNavy
-                .opacity(0.2)
+                // Subtler overlay to reduce intensity
+                .opacity(0.1)
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
                 .zIndex(1)

--- a/FlashlightsInTheDark_MacOS/View/OverlayViews.swift
+++ b/FlashlightsInTheDark_MacOS/View/OverlayViews.swift
@@ -24,7 +24,8 @@ struct FullScreenFlashView: View {
 struct ColorOverlayVeil: View {
     var body: some View {
         Color.purpleNavy
-            .opacity(0.2)
+            // Slightly lighter tint for more subtle overlay
+            .opacity(0.1)
             .ignoresSafeArea()
             .allowsHitTesting(false)
             .zIndex(1)


### PR DESCRIPTION
## Summary
- reduce intensity of the purple navy overlay veil

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68721b3ff4888332a728144ca2644b0e