### PR TITLE
Fix slot toggling by allowing clicks through glow overlay

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -463,6 +463,7 @@ struct ComposerConsoleView: View {
                             LightRaysView(color: .mintGlow)
                         }
                         .opacity((isTriggered || device.torchOn || state.glowingSlots.contains(device.id + 1)) ? 1 : 0)
+                        .allowsHitTesting(false)
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- ensure touch events pass through the glowing overlay on SlotCell

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872bd1683dc8332855c53c3cee378bb