### PR TITLE
Improve typing keyboard MIDI handling

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -22,6 +22,8 @@ struct ComposerConsoleView: View {
     private var keyLabels: [Int: String] {
         Dictionary(uniqueKeysWithValues: keyToSlot.map { ($0.value, String($0.key)) })
     }
+    // Mapper converting typed characters to MIDI note numbers
+    private lazy var typingMapper = TypingMidiMapper(keyToSlot: keyToSlot)
     private let slotRows: [[Int]] = [
         Array(1...12),
         Array(13...26),
@@ -311,20 +313,9 @@ struct ComposerConsoleView: View {
                             state.startEnvelopeAll()
                             return
                         }
-                        if let slot = keyToSlot[char] {
-                            let idx = slot - 1
-                            triggeredSlots.insert(slot)
-                            switch state.keyboardTriggerMode {
-                            case .torch:
-                                state.flashOn(id: idx)
-                            case .sound:
-                                let device = state.devices[idx]
-                                state.triggerSound(device: device)
-                            case .both:
-                                state.flashOn(id: idx)
-                                let deviceBoth = state.devices[idx]
-                                state.triggerSound(device: deviceBoth)
-                            }
+                        if let note = typingMapper.note(for: char) {
+                            triggeredSlots.insert(Int(note))
+                            state.typingNoteOn(note)
                             return
                         }
                     },
@@ -334,20 +325,9 @@ struct ComposerConsoleView: View {
                             state.releaseEnvelopeAll()
                             return
                         }
-                        if let slot = keyToSlot[char] {
-                            let idx = slot - 1
-                            triggeredSlots.remove(slot)
-                            switch state.keyboardTriggerMode {
-                            case .torch:
-                                state.flashOff(id: idx)
-                            case .sound:
-                                let device = state.devices[idx]
-                                state.stopSound(device: device)
-                            case .both:
-                                state.flashOff(id: idx)
-                                let deviceBoth = state.devices[idx]
-                                state.stopSound(device: deviceBoth)
-                            }
+                        if let note = typingMapper.note(for: char) {
+                            triggeredSlots.remove(Int(note))
+                            state.typingNoteOff(note)
                             return
                         }
                     }

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -786,3 +786,18 @@ extension ConsoleState {
         logMidi("CC \(cc) val \(value)")
     }
 }
+
+// MARK: - Typing MIDI Dispatch
+extension ConsoleState {
+    /// Send a MIDI Note On from the typing keyboard and handle it like incoming MIDI.
+    public func typingNoteOn(_ note: UInt8, velocity: UInt8 = 127) {
+        handleNoteOn(note: note, velocity: velocity)
+        midi.sendNoteOn(note, velocity: velocity)
+    }
+
+    /// Send a MIDI Note Off from the typing keyboard and handle it like incoming MIDI.
+    public func typingNoteOff(_ note: UInt8) {
+        handleNoteOff(note: note)
+        midi.sendNoteOff(note)
+    }
+}

--- a/FlashlightsInTheDark_MacOS/ViewModel/TypingMidiMapper.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/TypingMidiMapper.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Maps typing keyboard characters to MIDI note numbers.
+struct TypingMidiMapper {
+    private let keyToNote: [Character: UInt8]
+
+    init(keyToSlot: [Character: Int]) {
+        var map: [Character: UInt8] = [:]
+        for (key, slot) in keyToSlot {
+            if slot > 0 && slot < 128 {
+                map[key] = UInt8(slot)
+            }
+        }
+        self.keyToNote = map
+    }
+
+    func note(for char: Character) -> UInt8? {
+        keyToNote[char]
+    }
+}


### PR DESCRIPTION
## Summary
- map keystrokes to MIDI notes with `TypingMidiMapper`
- add typing MIDI dispatch helpers in `ConsoleState`
- route key presses through MIDI pipeline in `ComposerConsoleView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872be01794483329df9b9dadce89e2b