### PR TITLE
Fix state mutation for typing keys

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -5,7 +5,6 @@ struct ComposerConsoleView: View {
     @EnvironmentObject var state: ConsoleState
     @State private var showRouting: Bool = false
 
-    @State private var triggeredSlots: Set<Int> = []
     // Strobe effect state
     @State private var strobeActive: Bool = false
     @State private var strobeOn: Bool = false
@@ -256,7 +255,7 @@ struct ComposerConsoleView: View {
                                     SlotCell(device: device,
                                              keyLabel: keyLabels[slot],
                                              outline: slotOutlineColors[slot],
-                                             isTriggered: triggeredSlots.contains(slot))
+                                             isTriggered: state.triggeredSlots.contains(slot))
                                 }
                             }
                             .frame(maxWidth: .infinity)
@@ -314,7 +313,7 @@ struct ComposerConsoleView: View {
                             return
                         }
                         if let note = typingMapper.note(for: char) {
-                            triggeredSlots.insert(Int(note))
+                            state.addTriggeredSlot(Int(note))
                             state.typingNoteOn(note)
                             return
                         }
@@ -326,7 +325,7 @@ struct ComposerConsoleView: View {
                             return
                         }
                         if let note = typingMapper.note(for: char) {
-                            triggeredSlots.remove(Int(note))
+                            state.removeTriggeredSlot(Int(note))
                             state.typingNoteOff(note)
                             return
                         }

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -59,6 +59,8 @@ public final class ConsoleState: ObservableObject, Sendable {
 
     // Slots currently glowing for UI feedback
     @Published public var glowingSlots: Set<Int> = []
+    /// Slots currently triggered via typing keyboard
+    @Published public var triggeredSlots: Set<Int> = []
 
     private let tripleTriggers: [Int: [Int]] = [
         1: [27, 41, 42],
@@ -151,6 +153,15 @@ public final class ConsoleState: ObservableObject, Sendable {
             try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
             glowingSlots.remove(slot)
         }
+    }
+
+    /// Track pressed typing slots for UI feedback
+    public func addTriggeredSlot(_ slot: Int) {
+        triggeredSlots.insert(slot)
+    }
+
+    public func removeTriggeredSlot(_ slot: Int) {
+        triggeredSlots.remove(slot)
     }
 
     /// Append a MIDI message string to the log, trimming to last 20 entries.


### PR DESCRIPTION
## Summary
- move `triggeredSlots` storage into `ConsoleState`
- provide `addTriggeredSlot` and `removeTriggeredSlot` helpers
- update `ComposerConsoleView` to use the new observable state

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6872c115b4648332800d66be53922d0b