### PR TITLE
Add backslash toggle for all lights

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -299,6 +299,10 @@ struct ComposerConsoleView: View {
                             state.startEnvelopeAll()
                             return
                         }
+                        if char == "\\" {
+                            state.toggleAllTorches()
+                            return
+                        }
                         if char == "=" {
                             state.strobeActive.toggle()
                             return

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Sound & Light Checks
 
 ⌘+Shift+A (All Audio Test) — set phone volumes to 100 %.
 
+Press `\` (backslash) to toggle all flashlights on/off.
+
 During the Piece
 
 Follow score or DAW timeline.


### PR DESCRIPTION
## Summary
- add `\` keyboard shortcut in `ComposerConsoleView` to toggle all flashlights
- document new shortcut in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872d398027083329e296ef811e2ade4