### PR TITLE
Fix network restart when scene becomes active

### DIFF
--- a/FlashlightsInTheDark_MacOS/ContentView.swift
+++ b/FlashlightsInTheDark_MacOS/ContentView.swift
@@ -8,7 +8,11 @@ struct ContentView: View {
         ComposerConsoleView()
             .environmentObject(state)
             .onChange(of: phase) { _, newPhase in
-                if newPhase != .active { state.shutdown() }
+                if newPhase == .active {
+                    Task { await state.startNetwork() }
+                } else {
+                    state.shutdown()
+                }
             }
     }
 }


### PR DESCRIPTION
## Summary
- ensure network broadcasting restarts when returning to the active scene

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872f7a86e488332b17a492816565e56