### PR TITLE
Fix build error using POSIXError

### DIFF
--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -3,6 +3,7 @@ import Combine
 import SwiftUI
 import NIOPosix
 //import Network   // auto-discovery removed
+import Darwin           // for POSIXError & EHOSTDOWN
 
 /// Possible device statuses for build/run lifecycle
 public enum DeviceStatus: String, Sendable {
@@ -789,9 +790,9 @@ extension ConsoleState {
                 }
             }
             print("[ConsoleState] Network stack started ✅")
-        } catch let err as IOError where err.errnoCode == EHOSTDOWN {
-            lastLog = "⚠️ No active network interface" 
-            print("⚠️ startNetwork host down: \(err)")
+        } catch let err as POSIXError where err.code == .EHOSTDOWN {
+            lastLog = "⚠️ No active network interface"
+            print("^Δ startNetwork host down: \(err)")
             isBroadcasting = false
         } catch {
             lastLog = "⚠️ Network start failed: \(error)"


### PR DESCRIPTION
## Summary
- import Darwin so POSIXError and EHOSTDOWN are available
- handle host-down case with `POSIXError` instead of nonexistent `IOError`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687321900cdc8332afc0c61fd79050ef