### PR TITLE
Fix build warnings

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -355,8 +355,8 @@ struct ComposerConsoleView: View {
                 .allowsHitTesting(false)
                 .zIndex(1)
         }
-        .onChange(of: state.strobeActive) { active in
-            if active {
+        .onChange(state.strobeActive) {
+            if state.strobeActive {
                 withAnimation(Animation.linear(duration: 0.1).repeatForever(autoreverses: true)) {
                     strobeOn.toggle()
                 }

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -784,7 +784,7 @@ extension ConsoleState {
             // need to call the async `deviceDiscovered(slot:ip:)` that lives on the
             // MainActor.  Wrap the call in a detached Task so the compiler gets the
             // synchronous signature it expects.
-            await broadcaster.registerHelloHandler { [weak self] slot, ip in
+            broadcaster.registerHelloHandler { [weak self] slot, ip in
                 Task { @MainActor in
                     await self?.deviceDiscovered(slot: slot, ip: ip)
                 }


### PR DESCRIPTION
## Summary
- fix `.onChange` deprecation in `ComposerConsoleView`
- remove unnecessary `await` in `ConsoleState`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687323b692248332b0086ba1eb84b8dc