### PR TITLE
Fix async call in ConsoleState.startNetwork

### DIFF
--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -780,13 +780,11 @@ extension ConsoleState {
             let broadcaster = try await broadcasterTask.value
             try await broadcaster.start()
 
-            // `registerHelloHandler` expects a **synchronous** closure, but we still
-            // need to call the async `deviceDiscovered(slot:ip:)` that lives on the
-            // MainActor.  Wrap the call in a detached Task so the compiler gets the
-            // synchronous signature it expects.
-            broadcaster.registerHelloHandler { [weak self] slot, ip in
+            // Call must be awaited because registerHelloHandler is actor-isolated.
+            // deviceDiscovered is a synchronous @MainActor method, so no `await`.
+            await broadcaster.registerHelloHandler { [weak self] slot, ip in
                 Task { @MainActor in
-                    await self?.deviceDiscovered(slot: slot, ip: ip)
+                    self?.deviceDiscovered(slot: slot, ip: ip)
                 }
             }
             print("[ConsoleState] Network stack started ✅")


### PR DESCRIPTION
## Summary
- wait for actor-isolated `registerHelloHandler`
- remove unnecessary await for `deviceDiscovered`

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68732bdcb0e08332a40b8fd30c7d5fe5