### PR TITLE
Fix .onChange usage in ComposerConsoleView

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -355,7 +355,8 @@ struct ComposerConsoleView: View {
                 .allowsHitTesting(false)
                 .zIndex(1)
         }
-        .onChange(state.strobeActive) {
+        // Respond to strobe state changes
+        .onChange(of: state.strobeActive) { _ in
             if state.strobeActive {
                 withAnimation(Animation.linear(duration: 0.1).repeatForever(autoreverses: true)) {
                     strobeOn.toggle()


### PR DESCRIPTION
## Summary
- correct `.onChange` syntax in `ComposerConsoleView`
- add unused closure parameter to satisfy SwiftUI signature

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68732e902cac8332a63f7b2ac69df95c