### PR TITLE
Send OSC strobe messages directly

### DIFF
--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -536,28 +536,32 @@ public final class ConsoleState: ObservableObject, Sendable {
         strobeTask?.cancel()
         strobeTask = Task.detached { [weak self] in
             guard let self = self else { return }
-            await MainActor.run { self.lastLog = "⚡️ Strobe (CC1) active" }
-            var on = true
-            let interval: UInt64 = 100_000_000 // 100 ms half-cycle (~5 Hz)
-            while await self.strobeActive {
-                let val: UInt8 = on ? 127 : 0
-                await MainActor.run {
-                    for ch in 0..<16 {
-                        self.midi.setChannel(ch + 1)
-                        self.midi.sendControlChange(1, value: val)
+            await MainActor.run { self.lastLog = "⚡️ Strobe active" }
+            do {
+                let osc = try await self.broadcasterTask.value
+                let devicesList = await self.devices
+                var on = true
+                let interval: UInt64 = 100_000_000 // 100 ms half-cycle (~5 Hz)
+                while await self.strobeActive {
+                    for d in devicesList where !d.isPlaceholder {
+                        do {
+                            if on {
+                                try await osc.send(FlashOn(index: Int32(d.id + 1), intensity: 1))
+                            } else {
+                                try await osc.send(FlashOff(index: Int32(d.id + 1)))
+                            }
+                        } catch {}
                     }
+                    on.toggle()
+                    try? await Task.sleep(nanoseconds: interval)
                 }
-                on.toggle()
-                try? await Task.sleep(nanoseconds: interval)
-            }
-            await MainActor.run {
-                for ch in 0..<16 {
-                    self.midi.setChannel(ch + 1)
-                    self.midi.sendControlChange(1, value: 0)
+                for d in devicesList where !d.isPlaceholder {
+                    do { try await osc.send(FlashOff(index: Int32(d.id + 1))) } catch {}
                 }
-                self.midi.setChannel(self.outputChannel)
-                self.lastLog = "⚡️ Strobe stopped"
+            } catch {
+                print("⚠️ startStrobe error: \(error)")
             }
+            await MainActor.run { self.lastLog = "⚡️ Strobe stopped" }
         }
     }
 


### PR DESCRIPTION
## Summary
- strobe no longer uses MIDI CCs
- broadcast FlashOn/FlashOff in startStrobe()

## Testing
- `python3 -m py_compile Flashlights_Midi_Panel_Simulator.py Little_OSC_Test-sender.py scripts/choir_onboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68733b1f1c308332a79367a80c58bee5