### PR TITLE
Support torch brightness levels

### DIFF
--- a/flashlights_client/android/app/src/main/kotlin/com/example/flashlights_client/MainActivity.kt
+++ b/flashlights_client/android/app/src/main/kotlin/com/example/flashlights_client/MainActivity.kt
@@ -1,5 +1,54 @@
 package com.example.flashlights_client
 
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.Build
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import kotlin.math.roundToInt
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "ai.keex.flashlights/torch"
+        ).setMethodCallHandler { call, result ->
+            if (call.method == "setTorchLevel") {
+                val level = call.arguments as Double
+                try {
+                    setTorchLevel(level)
+                    result.success(null)
+                } catch (e: Exception) {
+                    result.error("TORCH_ERROR", e.message, null)
+                }
+            } else {
+                result.notImplemented()
+            }
+        }
+    }
+
+    private fun setTorchLevel(level: Double) {
+        val cm = getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        val cameraId = cm.cameraIdList.firstOrNull { id ->
+            val chars = cm.getCameraCharacteristics(id)
+            chars.get(CameraCharacteristics.FLASH_INFO_AVAILABLE) == true
+        } ?: return
+
+        if (level <= 0.0) {
+            cm.setTorchMode(cameraId, false)
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val max = cm.getCameraCharacteristics(cameraId)
+                .get(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL) ?: 1
+            var intLevel = (level * max).roundToInt().coerceIn(1, max)
+            cm.turnOnTorchWithStrengthLevel(cameraId, intLevel)
+        } else {
+            cm.setTorchMode(cameraId, true)
+        }
+    }
+}

--- a/flashlights_client/ios/Runner/AppDelegate.swift
+++ b/flashlights_client/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import AVFoundation
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,40 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+
+    let controller = window?.rootViewController as? FlutterViewController
+    let channel = FlutterMethodChannel(name: "ai.keex.flashlights/torch",
+                                       binaryMessenger: controller!.binaryMessenger)
+
+    channel.setMethodCallHandler { call, result in
+      if call.method == "setTorchLevel" {
+        if let level = call.arguments as? Double {
+          self.setTorchLevel(level: level)
+          result(nil)
+        } else {
+          result(FlutterError(code: "BAD_ARGS", message: nil, details: nil))
+        }
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func setTorchLevel(level: Double) {
+    guard let device = AVCaptureDevice.default(for: .video), device.hasTorch else { return }
+    do {
+      try device.lockForConfiguration()
+      if level <= 0 {
+        device.torchMode = .off
+      } else {
+        let clamped = min(max(level, 0.0), 1.0)
+        try device.setTorchModeOn(level: Float(clamped))
+      }
+      device.unlockForConfiguration()
+    } catch {
+      NSLog("Torch error: \(error)")
+    }
   }
 }


### PR DESCRIPTION
## Summary
- enable variable flashlight brightness in mobile client
- add native channel to set torch strength on iOS and Android
- use new channel in `/flash/on` and `/flash/off` handlers

## Testing
- `git status --short`
- *No automated tests run due to missing `flutter` SDK in the environment*


------
https://chatgpt.com/codex/tasks/task_e_6873521855808332862d5b82ad2edfd0