### PR TITLE
Fix strobe compile issue on macOS

### DIFF
--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -566,12 +566,11 @@ public final class ConsoleState: ObservableObject, Sendable {
 
                 while await self.strobeActive {
                     let intensity = 0.5 * (1 + sin(phase))
-                    await MainActor.run {
-                        for d in self.devices where !d.isPlaceholder {
-                            try? await osc.send(
-                                FlashOn(index: Int32(d.id + 1), intensity: Float32(intensity))
-                            )
-                        }
+
+                    for d in devicesList where !d.isPlaceholder {
+                        try? await osc.send(
+                            FlashOn(index: Int32(d.id + 1), intensity: Float32(intensity))
+                        )
                     }
 
                     phase += twoPi * oscillationHz / updateHz


### PR DESCRIPTION
## Summary
- avoid passing an async closure to `MainActor.run` in `startStrobe`

## Testing
- `swiftc FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift -o /tmp/out` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68736da319308332a47b53b6e6d8f0eb