### PR TITLE
Add Glow Ramp strobe option

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -54,13 +54,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             guard let chars = event.charactersIgnoringModifiers?.lowercased(),
                   let c = chars.first else { return event }
-            // Envelope trigger on “0” key (ADSR all lamps)
-            if c == "0" {
-                if event.type == .keyDown {
-                    self.state.startEnvelopeAll()
-                } else {
-                    self.state.releaseEnvelopeAll()
-                }
+            // Glow Ramp toggle on "0"
+            if c == "0" && event.type == .keyDown {
+                self.state.glowRampActive.toggle()
                 return nil
             }
             // Mapping from keyboard key to real slot number


### PR DESCRIPTION
## Summary
- implement new Glow Ramp strobe mode in ConsoleState
- expose Glow Ramp controls in ComposerConsoleView
- map the `0` key and MIDI note 72 to Glow Ramp in AppDelegate and MIDI handling
- rename existing strobe buttons

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68742d94d2c48332a748706051b92c62