### PR TITLE
Add Slow Glow Ramp strobe

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -54,13 +54,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             guard let chars = event.charactersIgnoringModifiers?.lowercased(),
                   let c = chars.first else { return event }
-            // Envelope trigger on “0” key (ADSR all lamps)
-            if c == "0" {
-                if event.type == .keyDown {
-                    self.state.startEnvelopeAll()
-                } else {
-                    self.state.releaseEnvelopeAll()
-                }
+            // Glow Ramp toggle on "]" and Slow Glow Ramp on "["
+            if c == "]" && event.type == .keyDown {
+                self.state.glowRampActive.toggle()
+                return nil
+            }
+            if c == "[" && event.type == .keyDown {
+                self.state.slowGlowRampActive.toggle()
                 return nil
             }
             // Mapping from keyboard key to real slot number

--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -217,14 +217,28 @@ struct ComposerConsoleView: View {
                         .tint(anyTorchOn ? .red : Color.indigo.opacity(0.6))
                         .disabled(!state.isBroadcasting)
 
-                        Button(state.slowStrobeActive ? "Stop Slow" : "Slow Strobe") {
+                        Button(state.slowGlowRampActive ? "Stop Slow Glow" : "Slow Glow Ramp") {
+                            state.slowGlowRampActive.toggle()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.mintGlow)
+                        .disabled(!state.isBroadcasting)
+
+                        Button(state.glowRampActive ? "Stop Glow" : "Glow Ramp") {
+                            state.glowRampActive.toggle()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.mintGlow)
+                        .disabled(!state.isBroadcasting)
+
+                        Button(state.slowStrobeActive ? "Stop Medium" : "Medium Strobe") {
                             state.slowStrobeActive.toggle()
                         }
                         .buttonStyle(.borderedProminent)
                         .tint(.mintGlow)
                         .disabled(!state.isBroadcasting)
 
-                        Button(state.strobeActive ? "Stop Strobe" : "Strobe") {
+                        Button(state.strobeActive ? "Stop Rapid" : "Rapid Strobe") {
                             state.strobeActive.toggle()
                         }
                         .buttonStyle(.borderedProminent)
@@ -298,7 +312,7 @@ struct ComposerConsoleView: View {
             }
             // Overlay effects stacked above console content
             .overlay(
-                FullScreenFlashView(strobeActive: state.strobeActive || state.slowStrobeActive, strobeOn: strobeOn)
+                FullScreenFlashView(strobeActive: state.strobeActive || state.slowStrobeActive || state.glowRampActive || state.slowGlowRampActive, strobeOn: strobeOn)
                     .environmentObject(state)
             )
             .overlay(
@@ -307,9 +321,12 @@ struct ComposerConsoleView: View {
             .overlay(
                 KeyCaptureView(
                     onKeyDown: { char in
-                        // Envelope on “0”
-                        if char == "0" {
-                            state.startEnvelopeAll()
+                        if char == "]" {
+                            state.glowRampActive.toggle()
+                            return
+                        }
+                        if char == "[" {
+                            state.slowGlowRampActive.toggle()
                             return
                         }
                         if char == "\\" {
@@ -332,11 +349,6 @@ struct ComposerConsoleView: View {
                         }
                     },
                     onKeyUp: { char in
-                        // Envelope release on “0”
-                        if char == "0" {
-                            state.releaseEnvelopeAll()
-                            return
-                        }
                         if let note = typingMapper.note(for: char) {
                             let slot = Int(note) - 35
                             state.removeTriggeredSlot(slot)
@@ -373,11 +385,23 @@ struct ComposerConsoleView: View {
         .onChange(of: state.slowStrobeActive) { _ in
             updateStrobeAnimation()
         }
+        .onChange(of: state.glowRampActive) { _ in
+            updateStrobeAnimation()
+        }
+        .onChange(of: state.slowGlowRampActive) { _ in
+            updateStrobeAnimation()
+        }
     }
 
     private func updateStrobeAnimation() {
-        let isActive = state.strobeActive || state.slowStrobeActive
-        let duration = state.slowStrobeActive ? 0.4 : 0.1
+        let isActive = state.strobeActive || state.slowStrobeActive || state.glowRampActive || state.slowGlowRampActive
+        let duration: Double = {
+            if state.strobeActive { return 0.1 }
+            if state.slowStrobeActive { return 0.4 }
+            if state.glowRampActive { return 0.8 }
+            if state.slowGlowRampActive { return 1.6 }
+            return 0.1
+        }()
         if isActive {
             withAnimation(Animation.linear(duration: duration).repeatForever(autoreverses: true)) {
                 strobeOn.toggle()

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -143,9 +143,35 @@ public final class ConsoleState: ObservableObject, Sendable {
         didSet {
             if slowStrobeActive {
                 strobeActive = false
+                glowRampActive = false
                 startSlowStrobe()
             } else {
                 stopSlowStrobe()
+            }
+        }
+    }
+    /// Whether the glow ramp effect is active.
+    @Published public var glowRampActive: Bool = false {
+        didSet {
+            if glowRampActive {
+                strobeActive = false
+                slowStrobeActive = false
+                startGlowRamp()
+            } else {
+                stopGlowRamp()
+            }
+        }
+    }
+    /// Whether the slow glow ramp effect is active.
+    @Published public var slowGlowRampActive: Bool = false {
+        didSet {
+            if slowGlowRampActive {
+                strobeActive = false
+                slowStrobeActive = false
+                glowRampActive = false
+                startSlowGlowRamp()
+            } else {
+                stopSlowGlowRamp()
             }
         }
     }
@@ -170,6 +196,10 @@ public final class ConsoleState: ObservableObject, Sendable {
     private var strobeTask: Task<Void, Never>?
     // Slow strobe oscillation task
     private var slowStrobeTask: Task<Void, Never>?
+    // Glow ramp oscillation task
+    private var glowRampTask: Task<Void, Never>?
+    // Slow glow ramp oscillation task
+    private var slowGlowRampTask: Task<Void, Never>?
 
     /// Recalculate `isAnyTorchOn` based on current device states.
     private func updateAnyTorchOn() {
@@ -665,6 +695,124 @@ public final class ConsoleState: ObservableObject, Sendable {
             }
         }
     }
+
+    private func startGlowRamp() {
+        glowRampTask?.cancel()
+        glowRampTask = Task.detached { [weak self] in
+            guard let self = self else { return }
+
+            let oscillationHz: Float = 0.625      // half speed of medium strobe
+            let updateHz: Float = 12
+            let updateIntervalNs = UInt64(1_000_000_000 / updateHz)
+
+            await MainActor.run { self.lastLog = "⚡️ Glow Ramp active (12 Hz updates)" }
+            do {
+                let osc = try await self.broadcasterTask.value
+                let devicesList = await self.devices
+
+                var phase: Float = 0
+                let twoPi: Float = .pi * 2
+
+                while await self.glowRampActive {
+                    let intensity = 0.5 * (1 + sin(phase))
+
+                    for d in devicesList where !d.isPlaceholder {
+                        try? await osc.send(
+                            FlashOn(index: Int32(d.id + 1), intensity: Float32(intensity))
+                        )
+                    }
+
+                    phase += twoPi * oscillationHz / updateHz
+                    if phase >= twoPi { phase -= twoPi }
+
+                    try? await Task.sleep(nanoseconds: updateIntervalNs)
+                }
+
+                for d in devicesList where !d.isPlaceholder {
+                    do { try await osc.send(FlashOff(index: Int32(d.id + 1))) } catch {}
+                }
+            } catch {
+                print("⚠️ startGlowRamp error: \(error)")
+            }
+            await MainActor.run { self.lastLog = "⚡️ Glow Ramp stopped" }
+        }
+    }
+
+    private func stopGlowRamp() {
+        let task = glowRampTask
+        glowRampTask = nil
+        task?.cancel()
+
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            await MainActor.run {
+                for ch in 0..<16 {
+                    self.midi.setChannel(ch + 1)
+                    self.midi.sendControlChange(1, value: 0)
+                }
+                self.midi.setChannel(self.outputChannel)
+            }
+        }
+    }
+
+    private func startSlowGlowRamp() {
+        slowGlowRampTask?.cancel()
+        slowGlowRampTask = Task.detached { [weak self] in
+            guard let self = self else { return }
+
+            let oscillationHz: Float = 0.3125     // half speed of glow ramp
+            let updateHz: Float = 12
+            let updateIntervalNs = UInt64(1_000_000_000 / updateHz)
+
+            await MainActor.run { self.lastLog = "⚡️ Slow Glow Ramp active (12 Hz updates)" }
+            do {
+                let osc = try await self.broadcasterTask.value
+                let devicesList = await self.devices
+
+                var phase: Float = 0
+                let twoPi: Float = .pi * 2
+
+                while await self.slowGlowRampActive {
+                    let intensity = 0.5 * (1 + sin(phase))
+
+                    for d in devicesList where !d.isPlaceholder {
+                        try? await osc.send(
+                            FlashOn(index: Int32(d.id + 1), intensity: Float32(intensity))
+                        )
+                    }
+
+                    phase += twoPi * oscillationHz / updateHz
+                    if phase >= twoPi { phase -= twoPi }
+
+                    try? await Task.sleep(nanoseconds: updateIntervalNs)
+                }
+
+                for d in devicesList where !d.isPlaceholder {
+                    do { try await osc.send(FlashOff(index: Int32(d.id + 1))) } catch {}
+                }
+            } catch {
+                print("⚠️ startSlowGlowRamp error: \(error)")
+            }
+            await MainActor.run { self.lastLog = "⚡️ Slow Glow Ramp stopped" }
+        }
+    }
+
+    private func stopSlowGlowRamp() {
+        let task = slowGlowRampTask
+        slowGlowRampTask = nil
+        task?.cancel()
+
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            await MainActor.run {
+                for ch in 0..<16 {
+                    self.midi.setChannel(ch + 1)
+                    self.midi.sendControlChange(1, value: 0)
+                }
+                self.midi.setChannel(self.outputChannel)
+            }
+        }
+    }
     
     // MARK: – Build only  🔨
     /// Build the app for a single device slot.
@@ -923,6 +1071,10 @@ extension ConsoleState {
             if let slots = tripleTriggers[group] {
                 triggerSlots(realSlots: slots)
             }
+        } else if val == 71 {
+            slowGlowRampActive = true
+        } else if val == 72 {
+            glowRampActive = true
         } else if val == 105 {
             strobeActive = true
         } else if val == 106 {
@@ -949,6 +1101,10 @@ extension ConsoleState {
                     stopSound(device: device)
                 }
             }
+        } else if val == 71 {
+            slowGlowRampActive = false
+        } else if val == 72 {
+            glowRampActive = false
         } else if val == 105 {
             strobeActive = false
         }


### PR DESCRIPTION
## Summary
- add new Slow Glow Ramp mode at half the Glow Ramp speed
- expose Slow Glow Ramp button and key triggers
- remap Glow Ramp activation key to `]`
- support MIDI note 71 for Slow Glow Ramp

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68742d94d2c48332a748706051b92c62