### PR TITLE
Fix slot MIDI channel menus and mapping

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -506,6 +506,7 @@ struct ComposerConsoleView: View {
                             .foregroundColor(.secondary)
                     }
                     .menuStyle(BorderlessButtonMenuStyle())
+                    .menuIndicator(.hidden)
                     .help("Assign MIDI channel for this slot")
                     .padding(4)
                 }

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -1056,8 +1056,10 @@ extension ConsoleState {
     fileprivate func handleNoteOn(note: UInt8, velocity: UInt8, channel: UInt8) {
         let val = Int(note)
         if val >= midiNoteOffset + 1 && val < midiNoteOffset + 1 + devices.count {
-            let idx = val - midiNoteOffset - 1
-            guard idx < devices.count else { return }
+            let slot = val - midiNoteOffset
+            guard let idx = devices.firstIndex(where: { $0.listeningSlot == slot }) else {
+                return
+            }
             let device = devices[idx]
             if device.midiChannel == Int(channel + 1) {
                 glowingSlots.insert(val)
@@ -1092,8 +1094,10 @@ extension ConsoleState {
     fileprivate func handleNoteOff(note: UInt8, channel: UInt8) {
         let val = Int(note)
         if val >= midiNoteOffset + 1 && val < midiNoteOffset + 1 + devices.count {
-            let idx = val - midiNoteOffset - 1
-            guard idx < devices.count else { return }
+            let slot = val - midiNoteOffset
+            guard let idx = devices.firstIndex(where: { $0.listeningSlot == slot }) else {
+                return
+            }
             let device = devices[idx]
             if device.midiChannel == Int(channel + 1) {
                 glowingSlots.remove(val)


### PR DESCRIPTION
## Summary
- hide extra menu arrow on per-slot MIDI channel selector
- map incoming MIDI notes by slot assignment instead of fixed index

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687456ca9c788332844c4dba9f82cd78