### PR TITLE
Update MIDI mapping to direct note numbers

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -5,8 +5,8 @@ import SwiftUI
 class AppDelegate: NSObject, NSApplicationDelegate {
     var state: ConsoleState!
     private let midi = MIDIManager()
-    /// Base MIDI note number for slot 0 (C2)
-    private let baseNote: UInt8 = 36
+    /// Base MIDI note number for slot 1
+    private let baseNote: UInt8 = 1
     /// Offsets within an octave for each column (as per prototype scale)
     private let noteOffsets: [UInt8] = [0, 1, 3, 4, 7, 8, 10, 11]
     /// Sustain pedal state (SPACE key)

--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -341,7 +341,7 @@ struct ComposerConsoleView: View {
                             return
                         }
                         if let note = typingMapper.note(for: char) {
-                            let slot = Int(note) - 35
+                            let slot = Int(note)
                             state.addTriggeredSlot(slot)
                             state.typingNoteOn(note)
                             return
@@ -349,7 +349,7 @@ struct ComposerConsoleView: View {
                     },
                     onKeyUp: { char in
                         if let note = typingMapper.note(for: char) {
-                            let slot = Int(note) - 35
+                            let slot = Int(note)
                             state.removeTriggeredSlot(slot)
                             state.typingNoteOff(note)
                             return

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -43,8 +43,8 @@ public final class ConsoleState: ObservableObject, Sendable {
     // Track ongoing run processes to monitor connection/state
     private var runProcesses: [Int: Process] = [:]
     private let midi = MIDIManager()
-    /// Base offset so MIDI note 36 corresponds to device 1
-    private let midiNoteOffset = 35
+    /// Base offset so MIDI note 1 corresponds to device 1
+    private let midiNoteOffset = 0
     private let allInputsLabel = "All MIDI Inputs"
 
     // MIDI device lists and selections

--- a/FlashlightsInTheDark_MacOS/ViewModel/TypingMidiMapper.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/TypingMidiMapper.swift
@@ -7,7 +7,7 @@ struct TypingMidiMapper {
     init(keyToSlot: [Character: Int]) {
         var map: [Character: UInt8] = [:]
         for (key, slot) in keyToSlot {
-            let note = slot + 35
+            let note = slot
             if note > 0 && note < 128 {
                 map[key] = UInt8(note)
             }


### PR DESCRIPTION
## Summary
- make MIDI offset zero so NoteOn value equals slot number
- update typing MIDI mapper to mirror new mapping
- adjust composer view to subtract no offset
- tweak base note for keyboard mapping

## Testing
- `python3 -m py_compile Flashlights_Midi_Panel_Simulator.py Little_OSC_Test-sender.py`


------
https://chatgpt.com/codex/tasks/task_e_68746c2d3f2083328be675ce1e71ea23