### PR TITLE
Unify keyboard mapping

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -64,12 +64,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 return nil
             }
             // Mapping from keyboard key to real slot number
-            let keyToSlot: [Character: Int] = [
-                "2": 1, "3": 3, "4": 4, "5": 5, "u": 7, "7": 9, "9": 12,
-                "q": 14, "w": 15, "d": 16, "e": 18, "r": 19, "k": 20, "i": 21,
-                "8": 23, "o": 24, "p": 25, "a": 27, "s": 29, "j": 34, "l": 38,
-                ";": 40, "x": 41, "c": 42, "v": 44, "m": 51, ",": 53, ".": 54
-            ]
+            let keyToSlot = KeyboardKeyToSlot
             if let slot = keyToSlot[c] {
                 let idx = slot - 1
                 let isDown = (event.type == .keyDown)

--- a/FlashlightsInTheDark_MacOS/Model/KeyboardMappings.swift
+++ b/FlashlightsInTheDark_MacOS/Model/KeyboardMappings.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Shared mapping from typing keyboard keys to real slot numbers.
+let KeyboardKeyToSlot: [Character: Int] = [
+    "2": 1, "3": 3, "4": 4, "5": 5, "u": 7, "7": 9, "9": 12,
+    "q": 14, "w": 15, "d": 16, "e": 18, "r": 19, "k": 20, "i": 21,
+    "8": 23, "o": 24, "p": 25, "a": 27, "s": 29, "j": 34, "l": 38,
+    ";": 40, "x": 41, "c": 42, "v": 44, "m": 51, ",": 53, ".": 54
+]

--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -13,12 +13,7 @@ struct ComposerConsoleView: View {
     @State private var strobeOn: Bool = false
     private let columns = Array(repeating: GridItem(.flexible()), count: 8)
     // Mapping from keyboard key to real slot number
-    private static let keyToSlot: [Character: Int] = [
-        "2": 1, "3": 3, "4": 4, "5": 5, "u": 7, "7": 9, "9": 12,
-        "q": 14, "w": 15, "d": 16, "e": 18, "r": 19, "k": 20, "i": 21,
-        "8": 23, "o": 24, "p": 25, "a": 27, "s": 29, "j": 34, "l": 38,
-        ";": 40, "x": 41, "c": 42, "v": 44, "m": 51, ",": 53, ".": 54
-    ]
+    private static let keyToSlot = KeyboardKeyToSlot
     // Reverse lookup so each slot can display its bound key
     private var keyLabels: [Int: String] {
         Dictionary(uniqueKeysWithValues: Self.keyToSlot.map { ($0.value, String($0.key)) })


### PR DESCRIPTION
## Summary
- add `KeyboardKeyToSlot` shared mapping
- use it in the Mac AppDelegate and ComposerConsoleView to keep typing triggers consistent

## Testing
- `swift --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749a51dd7c833282e0faf931c39fca