### PR TITLE
Add heartbeat and slot validation

### DIFF
--- a/FlashlightsInTheDark_MacOS/Network/OscBroadcaster+Generic.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscBroadcaster+Generic.swift
@@ -4,25 +4,31 @@ import NIOCore
 public extension OscBroadcaster {
     @inline(__always)
     func send<T: OscCodable>(_ model: T) async throws {
-        try await send(model.encode())
-        // For per-slot messages also send a directed copy  –––––––––
         switch model {
-        case let m as FlashOn:  try await directed(m.index, osc: m.encode())
-        case let m as FlashOff: try await directed(m.index, osc: m.encode())
-        case let m as AudioPlay:try await directed(m.index, osc: m.encode())
-        case let m as AudioStop:try await directed(m.index, osc: m.encode())
-        case let m as MicRecord:try await directed(m.index, osc: m.encode())
-        default: break          // /sync etc. stay broadcast-only
+        case let m as FlashOn:
+            try await directedOrBroadcast(slot: m.index, osc: m.encode())
+        case let m as FlashOff:
+            try await directedOrBroadcast(slot: m.index, osc: m.encode())
+        case let m as AudioPlay:
+            try await directedOrBroadcast(slot: m.index, osc: m.encode())
+        case let m as AudioStop:
+            try await directedOrBroadcast(slot: m.index, osc: m.encode())
+        case let m as MicRecord:
+            try await directedOrBroadcast(slot: m.index, osc: m.encode())
+        default:
+            try await send(model.encode())
         }
     }
-    // Helper – send to a single phone if we have its IP
-    private func directed(_ slot: Int32, osc: OSCMessage) async throws {
+    private func directedOrBroadcast(slot: Int32, osc: OSCMessage) async throws {
         let s = Int(slot)
-        guard let ip = dynamicIPs[s] ?? slotInfos[s]?.ip else { return }
-        var buf = channel.allocator.buffer(capacity: try osc.rawData().count)
-        buf.writeBytes(try osc.rawData())
-        let addr = try SocketAddress(ipAddress: ip, port: port)
-        try await channel.writeAndFlush(AddressedEnvelope(remoteAddress: addr, data: buf))
-        print("→ directed \(slot) @ \(ip)")
+        if let ip = dynamicIPs[s] ?? slotInfos[s]?.ip {
+            var buf = channel.allocator.buffer(capacity: try osc.rawData().count)
+            buf.writeBytes(try osc.rawData())
+            let addr = try SocketAddress(ipAddress: ip, port: port)
+            try await channel.writeAndFlush(AddressedEnvelope(remoteAddress: addr, data: buf))
+            print("→ directed \(slot) @ \(ip)")
+        } else {
+            try await send(osc)
+        }
     }
 }

--- a/flashlights_client/lib/model/client_state.dart
+++ b/flashlights_client/lib/model/client_state.dart
@@ -6,6 +6,7 @@ class ClientState {
     : myIndex = ValueNotifier<int>(
         const int.fromEnvironment('SLOT', defaultValue: 1),
       ),
+      udid = const String.fromEnvironment('UDID', defaultValue: 'unknown'),
       clockOffsetMs = 0.0,
       flashOn = ValueNotifier<bool>(false),
       audioPlaying = ValueNotifier<bool>(false),
@@ -14,6 +15,9 @@ class ClientState {
 
   /// Singer slot (uses the real slot number). Notifier so UI can react to changes at runtime.
   final ValueNotifier<int> myIndex;
+
+  /// Unique device identifier used for slot verification.
+  final String udid;
 
   /// Rolling average clock offset from /sync (ms).
   double clockOffsetMs;


### PR DESCRIPTION
## Summary
- verify slots using UDID and correct clients with `/set-slot`
- mark devices as lost when heartbeats stop
- switch to unicast once IP known
- add ack handling and logs
- allow client to announce UDID, send acks

## Testing
- `swift test` *(fails: Package.swift missing)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c3d8b9708332a39455bc79bf6a41