### PR TITLE
Ensure UI refresh on session load

### DIFF
--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -1467,9 +1467,11 @@ extension ConsoleState {
         try encoded.write(to: url)
     }
 
+    @MainActor
     private func readSession(from url: URL) throws {
         let data = try Data(contentsOf: url)
         let session = try JSONDecoder().decode(SessionData.self, from: data)
+        objectWillChange.send()
         for dev in session.devices {
             if let idx = devices.firstIndex(where: { $0.id == dev.id }) {
                 devices[idx].listeningSlot = dev.listeningSlot


### PR DESCRIPTION
## Summary
- send `objectWillChange` when session devices are applied

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6875c0df8cf88332b3cfc67cd2d91766