### PR TITLE
Update accent colors for tone sets and speakers

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -95,7 +95,7 @@ struct ComposerConsoleView: View {
                             ZStack {
                                 Circle()
                                     .fill(state.activeToneSets.contains(set)
-                                          ? Color.blue
+                                          ? Color.mintGlow
                                           : Color.gray.opacity(0.3))
                                     .frame(width: 40, height: 40)
                                 Text(set)
@@ -462,7 +462,7 @@ struct ComposerConsoleView: View {
                             state.triggerSound(device: device)
                         } label: {
                             Image(systemName: "speaker.wave.2.fill")
-                                .foregroundStyle(.cyan)
+                                .foregroundStyle(Color.mintGlow)
                                 .help("Trigger sound on \(device.name)…")
                         }
                         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- apply mintGlow accent color to active tone set buttons
- tint the speaker icons in slot cells with mintGlow

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6875d2800ee4833291df2e2ebbcacb11