### PR TITLE
Fix debugPrint missing import

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -12,6 +12,7 @@ import 'package:osc/osc.dart';
 import 'package:torch_light/torch_light.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mic_stream/mic_stream.dart' as mic;
 
 import '../model/client_state.dart';


### PR DESCRIPTION
## Summary
- add flutter foundation import to access `debugPrint`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d74673888332860b58cdb1dd0ea5