### PR TITLE
Fix OscSender.swift for OSCKit 1.0

### DIFF
--- a/FlashlightsInTheDark_MacOS/Network/OscSender.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscSender.swift
@@ -9,8 +9,12 @@ enum OscSender {
     static func send(bundle: OSCBundle, to ip: String) {
         let targetHost = (ip == "broadcast") ? "255.255.255.255" : ip
         do {
-            let client = OSCClient(address: targetHost, port: port)
-            try client.send(bundle)
+            let client = OSCClient()
+            if ip == "broadcast" {
+                client.isIPv4BroadcastEnabled = true
+            }
+            try client.start()
+            try client.send(bundle, to: targetHost, port: Self.port)
             print("✅ [OSC] Sent to \(targetHost): \(bundle.elements)")
         } catch {
             print("❌ [OSC] Failed to send to \(targetHost): \(error)")


### PR DESCRIPTION
## Summary
- update OscSender to use new OSCKit API

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6875d86a31308332ba86837986265c96