### PR TITLE
Fix codable conformance for ChoirDevice

### DIFF
--- a/FlashlightsInTheDark_MacOS/Model/ChoirDevice.swift
+++ b/FlashlightsInTheDark_MacOS/Model/ChoirDevice.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ChoirDevice: Identifiable, Sendable {
+public struct ChoirDevice: Codable, Identifiable, Sendable {
     public var id: Int
     public var torchOn: Bool
     public var audioPlaying: Bool


### PR DESCRIPTION
## Summary
- make `ChoirDevice` conform to `Codable`

## Testing
- `swiftc -emit-library -module-name Test FlashlightsInTheDark_MacOS/Model/ChoirDevice.swift -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_6875dc0e21908332aa7f007099d6b795