### PR TITLE
Flip tone set bracket orientation

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -145,11 +145,11 @@ struct ComposerConsoleView: View {
                             }
                         }
                         VStack(spacing: 0) {
-                            Text("⎧")
-                            Text("⎨")
-                            Text("⎩")
+                            Text("⎫")
+                            Text("⎬")
+                            Text("⎭")
                         }
-                        .font(.system(size: 20))
+                        .font(.system(size: 40))
                         Text("Sound Events")
                             .font(.subheadline)
                     }


### PR DESCRIPTION
## Summary
- adjust the bracket glyphs in Tone Sets to face the other direction
- make the bracket twice as large for better visibility

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f76dcb4883328653592922827957