### PR TITLE
Keep screen awake and persist singer slot

### DIFF
--- a/flashlights_client/lib/main.dart
+++ b/flashlights_client/lib/main.dart
@@ -3,6 +3,8 @@ import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:wakelock/wakelock.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'network/osc_listener.dart';
 // import 'dart:io';
@@ -33,6 +35,12 @@ Future<void> _bootstrapNative() async {
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await _bootstrapNative();
+  final prefs = await SharedPreferences.getInstance();
+  final savedSlot = prefs.getInt('lastSlot');
+  if (savedSlot != null && savedSlot != 0) {
+    client.myIndex.value = savedSlot;
+  }
+  Wakelock.enable();
   runApp(const FlashlightsApp());
 }
 
@@ -153,9 +161,11 @@ class _BootstrapState extends State<Bootstrap> {
                                     child: Text('Slot $slot'),
                                   ))
                               .toList(),
-                          onChanged: (newSlot) {
+                          onChanged: (newSlot) async {
                             if (newSlot != null) {
                               client.myIndex.value = newSlot;
+                              final prefs = await SharedPreferences.getInstance();
+                              await prefs.setInt('lastSlot', newSlot);
                             }
                           },
                         );

--- a/flashlights_client/pubspec.yaml
+++ b/flashlights_client/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   just_audio: ^0.9.37  # Audio playback
   mic_stream: ^0.7.2   # Raw mic samples/recording
   permission_handler: ^11.4.0  # camera / mic permissions (iOS / Android only)
+  wakelock: ^0.5.6     # Keep the screen awake during performances
+  shared_preferences: ^2.2.2  # Persist selected slot between launches
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- keep screens on during the performance
- remember chosen slot between launches

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f9df72a8833281dae3f6b176333b