### PR TITLE
Add tap-tempo cue and shutdown cleanup

### DIFF
--- a/FlashlightsInTheDark_MacOS/AppDelegate.swift
+++ b/FlashlightsInTheDark_MacOS/AppDelegate.swift
@@ -168,4 +168,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return event
         }
     }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        Task { @MainActor in
+            state.blackoutAll()
+            state.stopAllSounds()
+            state.shutdown()
+        }
+    }
 }

--- a/FlashlightsInTheDark_MacOS/Network/OscBroadcaster+Generic.swift
+++ b/FlashlightsInTheDark_MacOS/Network/OscBroadcaster+Generic.swift
@@ -15,6 +15,8 @@ public extension OscBroadcaster {
             try await directedOrBroadcast(slot: m.index, osc: m.encode())
         case let m as MicRecord:
             try await directedOrBroadcast(slot: m.index, osc: m.encode())
+        case _ as Tap:
+            try await send(model.encode())
         default:
             try await send(model.encode())
         }

--- a/FlashlightsInTheDark_MacOS/OscMessages.swift
+++ b/FlashlightsInTheDark_MacOS/OscMessages.swift
@@ -8,6 +8,7 @@ public enum OscAddress: String {
     case audioStop = "/audio/stop"
     case micRecord = "/mic/record"
     case sync      = "/sync"
+    case tap       = "/tap"
     /// Dynamically assign the listening slot on a client
     case setSlot   = "/set-slot"
 }
@@ -196,5 +197,22 @@ public struct SetSlot: OscCodable {
             OSCAddressPattern(Self.address.rawValue),
             values: [ slot ]
         )
+    }
+}
+
+// MARK: – Tap ---------------------------------------------------------------
+/// Simple tap/cue message from a proxy device
+public struct Tap: OscCodable {
+    public static let address: OscAddress = .tap
+
+    public init() {}
+
+    public init?(from message: OSCMessage) {
+        guard message.addressPattern == OSCAddressPattern(Self.address.rawValue) else { return nil }
+        self.init()
+    }
+
+    public func encode() -> OSCMessage {
+        OSCMessage(OSCAddressPattern(Self.address.rawValue), values: [])
     }
 }

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -258,6 +258,12 @@ public final class ConsoleState: ObservableObject, Sendable {
         }
     }
 
+    /// Handle a tap cue from the proxy device.
+    public func tapReceived() {
+        lastLog = "🎵 Tap signal received"
+        toggleAllTorches()
+    }
+
     /// Track pressed typing slots for UI feedback
     public func addTriggeredSlot(_ slot: Int) {
         triggeredSlots.insert(slot)
@@ -587,6 +593,13 @@ public final class ConsoleState: ObservableObject, Sendable {
             } catch {
                 print("Error stopping sound for slot \(device.id + 1): \(error)")
             }
+        }
+    }
+
+    /// Stop all audio playback on every device.
+    public func stopAllSounds() {
+        for device in devices where !device.isPlaceholder {
+            stopSound(device: device)
         }
     }
     
@@ -1132,6 +1145,11 @@ extension ConsoleState {
                 Task { @MainActor in
                     self?.lastLog = "✅ Ack from slot \(slot)"
                     self?.lastAckTimes[slot] = Date()
+                }
+            }
+            await broadcaster.registerTapHandler { [weak self] in
+                Task { @MainActor in
+                    self?.tapReceived()
                 }
             }
             heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in

--- a/flashlights_client/lib/main.dart
+++ b/flashlights_client/lib/main.dart
@@ -193,6 +193,28 @@ class _BootstrapState extends State<Bootstrap> {
                         );
                       },
                     ),
+                    const SizedBox(height: 24),
+                    ValueListenableBuilder<int>(
+                      valueListenable: client.myIndex,
+                      builder: (context, myIndex, _) {
+                        if (myIndex == 5) {
+                          return ElevatedButton(
+                            onPressed: () {
+                              OscListener.instance.sendCustom('/tap', []);
+                            },
+                            child: const Padding(
+                              padding: EdgeInsets.symmetric(
+                                  vertical: 12.0, horizontal: 32.0),
+                              child: Text(
+                                'TAP',
+                                style: TextStyle(fontSize: 32),
+                              ),
+                            ),
+                          );
+                        }
+                        return const SizedBox.shrink();
+                      },
+                    ),
                   ],
                 ),
               ),

--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -374,6 +374,17 @@ class OscListener {
     });
   }
 
+  /// Send a custom OSC message to the server. Best effort only.
+  void sendCustom(String address, List<Object> args) {
+    if (_socket == null) return;
+    final msg = OSCMessage(address, arguments: args);
+    try {
+      _socket!.send(msg);
+    } catch (e) {
+      print('[OSC] sendCustom error: $e');
+    }
+  }
+
   /* -------------------------------------------------------------------- */
   /*                               Teardown                                */
   /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- add new `/tap` OSC message and struct
- support registering tap handler in Mac broadcaster
- log and toggle lights on tap received
- send global flashlight and audio stop on Mac shutdown
- show a large TAP button on proxy device
- allow sending custom OSC messages from Flutter client

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ff2141fc8332b98ebdf37d9a0e92