### PR TITLE
Improve MIDI log resizing and scrolling

### DIFF
--- a/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
+++ b/FlashlightsInTheDark_MacOS/View/ComposerConsoleView.swift
@@ -245,13 +245,22 @@ struct ComposerConsoleView: View {
                     Divider()
                     Text("MIDI Log:")
                         .font(.headline)
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 2) {
-                            ForEach(state.midiLog.indices, id: \.self) { idx in
-                                Text(state.midiLog[idx])
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
+                    ScrollViewReader { proxy in
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 2) {
+                                ForEach(state.midiLog.indices, id: \.self) { idx in
+                                    Text(state.midiLog[idx])
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Color.clear.frame(height: 1).id("midiBottom")
                             }
+                        }
+                        .onChange(of: state.midiLog.count) { _ in
+                            proxy.scrollTo("midiBottom", anchor: .bottom)
+                        }
+                        .onAppear {
+                            proxy.scrollTo("midiBottom", anchor: .bottom)
                         }
                     }
                     .frame(height: midiLogHeight)
@@ -271,7 +280,7 @@ struct ComposerConsoleView: View {
                                                 startMidiLogHeight = midiLogHeight
                                             }
                                             let newHeight = (startMidiLogHeight ?? midiLogHeight) - value.translation.height
-                                            midiLogHeight = max(80, min(newHeight, 300))
+                                            midiLogHeight = max(80, min(newHeight, 500))
                                         }
                                         .onEnded { _ in
                                             startMidiLogHeight = nil

--- a/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
+++ b/FlashlightsInTheDark_MacOS/ViewModel/ConsoleState.swift
@@ -300,12 +300,11 @@ public final class ConsoleState: ObservableObject, Sendable {
         }
     }
 
-    /// Append a MIDI message string to the log, trimming to last 20 entries.
+    /// Append a MIDI message string to the log.  Older entries are retained so
+    /// the user can scroll back through the full history.  Callers should
+    /// consider truncating externally if extremely large logs become a concern.
     public func logMidi(_ message: String) {
         midiLog.append(message)
-        if midiLog.count > 20 {
-            midiLog.removeFirst(midiLog.count - 20)
-        }
     }
     
 


### PR DESCRIPTION
## Summary
- keep full MIDI log history
- add automatic scrolling to the bottom of the log
- allow resizing MIDI log panel up to 500 px high

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68760ebc45bc83328bb0f532ac003509