### PR TITLE
Fix manifest patching script paths

### DIFF
--- a/scripts/patch_manifests.sh
+++ b/scripts/patch_manifests.sh
@@ -2,12 +2,14 @@
 set -euo pipefail
 
 echo "🔧 Patching AndroidManifest.xml"
-MANIFEST='android/app/src/main/AndroidManifest.xml'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$REPO_ROOT/flashlights_client/android/app/src/main/AndroidManifest.xml"
 
 add_android_perm() {
   local PERM=$1
   if ! grep -q "$PERM" "$MANIFEST"; then
-    perl -0777 -pi -e "s|</manifest>|  <uses-permission android:name=\"$PERM\"/>\n</manifest>|" $MANIFEST
+    perl -0777 -pi -e "s|</manifest>|  <uses-permission android:name=\"$PERM\"/>\n</manifest>|" "$MANIFEST"
     echo "  + $PERM"
   fi
 }
@@ -21,23 +23,23 @@ add_android_perm android.permission.CHANGE_WIFI_MULTICAST_STATE
 # mark camera as non-location (API 34+)
 CAMERA_FLAG='<uses-permission android:name="android.permission.CAMERA" android:usesPermissionFlags="neverForLocation"/>'
 if ! grep -q "usesPermissionFlags=\"neverForLocation\"" "$MANIFEST"; then
-  perl -0777 -pi -e "s|<uses-permission android:name=\"android.permission.CAMERA\"/>|&\n  $CAMERA_FLAG|" $MANIFEST
+  perl -0777 -pi -e "s|<uses-permission android:name=\"android.permission.CAMERA\"/>|&\n  $CAMERA_FLAG|" "$MANIFEST"
   echo "  + camera neverForLocation flag"
 fi
 
 # Add foreground service inside <application>
 if ! grep -q '.KeepAliveService' "$MANIFEST"; then
-  perl -0777 -pi -e 's|</application>|  <service android:name=".KeepAliveService" android:exported="false" android:foregroundServiceType="mediaPlayback"/>\n</application>|' $MANIFEST
+  perl -0777 -pi -e 's|</application>|  <service android:name=".KeepAliveService" android:exported="false" android:foregroundServiceType="mediaPlayback"/>\n</application>|' "$MANIFEST"
   echo "  + KeepAliveService"
 fi
 
 echo "🔧 Patching iOS Info.plist"
-PLIST='ios/Runner/Info.plist'
+PLIST="$REPO_ROOT/flashlights_client/ios/Runner/Info.plist"
 
 insert_plist_key() {
   local KEY=$1; local VALUE=$2
   if ! grep -q "<key>$KEY</key>" "$PLIST"; then
-    perl -0777 -pi -e "s|</dict>|  <key>$KEY</key>\n  $VALUE\n</dict>|" $PLIST
+    perl -0777 -pi -e "s|</dict>|  <key>$KEY</key>\n  $VALUE\n</dict>|" "$PLIST"
     echo "  + $KEY"
   fi
 }
@@ -47,7 +49,7 @@ insert_plist_key NSMicrophoneUsageDescription '<string>Enables recording for cho
 
 # UIBackgroundModes array
 if ! grep -q '<key>UIBackgroundModes</key>' "$PLIST"; then
-  perl -0777 -pi -e 's|</dict>|  <key>UIBackgroundModes</key>\n  <array>\n    <string>audio</string>\n  </array>\n</dict>|' $PLIST
+  perl -0777 -pi -e 's|</dict>|  <key>UIBackgroundModes</key>\n  <array>\n    <string>audio</string>\n  </array>\n</dict>|' "$PLIST"
   echo "  + UIBackgroundModes → audio"
 fi
 


### PR DESCRIPTION
## Summary
- fix `patch_manifests.sh` so it always patches the Android and iOS manifests in `flashlights_client`
- quote file paths when invoking `perl`

## Testing
- `shellcheck scripts/patch_manifests.sh`
- `./scripts/patch_manifests.sh` *(then reverted changes)*

------
https://chatgpt.com/codex/tasks/task_e_687ddbddf9808332bab0cf418d1f3edf