### PR TITLE
Remove old osc package

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:just_audio/just_audio.dart';
-import 'package:osc/osc.dart';
+import 'osc_packet.dart';
 import 'osc_messages.dart';
 import 'package:torch_light/torch_light.dart';
 import 'package:screen_brightness/screen_brightness.dart';
@@ -34,19 +34,10 @@ OSCSocket _createBroadcastSocket({
     destination: InternetAddress('255.255.255.255'),
     destinationPort: serverPort,
   );
-
-  // Best‑effort: ask the wrapped RawDatagramSocket to allow broadcasting.
-  try {
-    // ignore: invalid_use_of_visible_for_testing_member, avoid_dynamic_calls
-    (socket as dynamic).rawSocket?.broadcastEnabled = true;
-  } catch (_) {
-    try {
-      // ignore: invalid_use_of_visible_for_testing_member, avoid_dynamic_calls
-      (socket as dynamic).socket?.broadcastEnabled = true;
-    } catch (_) {
-      // Some builds of the osc package don’t expose the inner socket.
-    }
-  }
+  // Best‑effort: create the socket immediately and allow broadcasting.
+  socket.bind().then((_) {
+    socket.rawSocket?.broadcastEnabled = true;
+  });
   return socket;
 }
 

--- a/flashlights_client/lib/network/osc_messages.dart
+++ b/flashlights_client/lib/network/osc_messages.dart
@@ -1,5 +1,5 @@
 /// OSC message definitions for Flutter
-import 'package:osc/osc.dart';
+import 'osc_packet.dart';
 
 enum OscAddress {
   flashOn('/flash/on'),

--- a/flashlights_client/lib/network/osc_packet.dart
+++ b/flashlights_client/lib/network/osc_packet.dart
@@ -1,0 +1,94 @@
+// Minimal OSC message and socket utilities.
+// Implements just enough of OSC encoding for this app.
+
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:convert';
+
+class OSCMessage {
+  final String address;
+  final List<Object> arguments;
+
+  OSCMessage(this.address, {List<Object> arguments = const []})
+      : arguments = List<Object>.from(arguments);
+
+  List<int> _stringBytes(String s) {
+    final bytes = utf8.encode(s);
+    final padded = BytesBuilder()
+      ..add(bytes)
+      ..addByte(0);
+    final pad = (4 - (bytes.length + 1) % 4) % 4;
+    if (pad > 0) padded.add(List.filled(pad, 0));
+    return padded.toBytes();
+  }
+
+  List<int> toBytes() {
+    final builder = BytesBuilder();
+    builder.add(_stringBytes(address));
+
+    final typeTags = StringBuffer(',');
+    for (final arg in arguments) {
+      if (arg is int) {
+        typeTags.write('i');
+      } else if (arg is double) {
+        typeTags.write('f');
+      } else if (arg is String) {
+        typeTags.write('s');
+      } else {
+        throw ArgumentError('Unsupported OSC argument type: ${arg.runtimeType}');
+      }
+    }
+    builder.add(_stringBytes(typeTags.toString()));
+
+    for (final arg in arguments) {
+      if (arg is int) {
+        final b = ByteData(4)..setInt32(0, arg, Endian.big);
+        builder.add(b.buffer.asUint8List());
+      } else if (arg is double) {
+        final b = ByteData(4)..setFloat32(0, arg, Endian.big);
+        builder.add(b.buffer.asUint8List());
+      } else if (arg is String) {
+        builder.add(_stringBytes(arg));
+      }
+    }
+
+    return builder.toBytes();
+  }
+}
+
+class OSCSocket {
+  final InternetAddress serverAddress;
+  final int serverPort;
+  final InternetAddress destination;
+  final int destinationPort;
+  RawDatagramSocket? _socket;
+
+  OSCSocket({
+    required this.serverAddress,
+    required this.serverPort,
+    required this.destination,
+    required this.destinationPort,
+  });
+
+  Future<void> _ensureSocket() async {
+    _socket ??= await RawDatagramSocket.bind(serverAddress, serverPort,
+        reuseAddress: true, reusePort: true);
+  }
+
+  Future<void> bind() async {
+    await _ensureSocket();
+  }
+
+  Future<void> close() async {
+    _socket?.close();
+    _socket = null;
+  }
+
+  Future<int> send(OSCMessage msg) async {
+    await _ensureSocket();
+    return _socket!
+        .send(msg.toBytes(), destination, destinationPort);
+  }
+
+  RawDatagramSocket? get rawSocket => _socket;
+}

--- a/flashlights_client/pubspec.yaml
+++ b/flashlights_client/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
 
   # --- runtime plugins ---
   cupertino_icons: ^1.0.8
-  osc: ^1.0.0          # Open-Sound-Control packets
   torch_light: ^1.1.0  # Flash/torch control (on/off only – no brightness)
   screen_brightness: ^2.1.5 # Control screen brightness for strobe dimming
   just_audio: ^0.9.37  # Audio playback


### PR DESCRIPTION
## Summary
- swap out deprecated `osc` package for minimal `OSCMessage` and `OSCSocket`
- remove `osc` dependency from `pubspec.yaml`
- fix import in `osc_messages.dart`

## Testing
- `apt-get update` *(fails: blocked domain)*


------
https://chatgpt.com/codex/tasks/task_e_688042e69c8883328b95707ad134afbf