### PR TITLE
Fix OscListener import

### DIFF
--- a/flashlights_client/lib/main.dart
+++ b/flashlights_client/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:wakelock/wakelock.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'network/osc_listener.dart';
+import 'package:flashlights_client/network/osc_listener.dart';
 // import 'dart:io';
 // import 'dart:convert';
 // removed discovery code


### PR DESCRIPTION
## Summary
- use a package import for `OscListener` in the Flutter client

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805dcfaff48332a96e96ac36628717