### PR TITLE
Fix closing brace error in OscListener

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -417,4 +417,4 @@ class OscListener {
 
     print('[OSC] Listener stopped');
   }
-}
+


### PR DESCRIPTION
## Summary
- remove stray closing brace at end of `osc_listener.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806ce8b28c8332a8b31746dd9f90b7