### PR TITLE
Add OscListener stop cleanup, manifest patch

### DIFF
--- a/flashlights_client/android/app/src/main/AndroidManifest.xml
+++ b/flashlights_client/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <!-- ── Runtime permissions we rely on ─────────────────────────────── -->
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.CAMERA" android:usesPermissionFlags="neverForLocation"/>
     <uses-permission android:name="android.permission.FLASHLIGHT"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>

--- a/flashlights_client/lib/main.dart
+++ b/flashlights_client/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+import 'dart:async' show unawaited;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -77,7 +78,7 @@ class _BootstrapState extends State<Bootstrap> {
 
   @override
   void dispose() {
-    flosc.OscListener.instance.stop();
+    unawaited(flosc.OscListener.instance.stop());
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- fix Android manifest entry for camera permission and keep service
- call OscListener teardown without await
- import `unawaited` in main

## Testing
- `bash scripts/patch_manifests.sh`
- `flutter clean` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880786d28388332b092d9e159620d81