### PR TITLE
Fix OscListener teardown

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -418,3 +418,5 @@ class OscListener {
     print('[OSC] Listener stopped');
   }
 
+}
+


### PR DESCRIPTION
## Summary
- close the OscListener class properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68807c7f81f48332b3627f0119ea248d