### PR TITLE
Fix stray brace in OSC listener

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -262,7 +262,6 @@ class OscListener {
                 (client.clockOffsetMs + offset) / 2; // Simple smoothing.
             print('[OSC] Clock offset updated to ${client.clockOffsetMs} ms');
           }
-        }
         break;
 
       case '/hello':


### PR DESCRIPTION
## Summary
- remove an extra closing brace from the `/sync` case in `osc_listener.dart`

## Testing
- `apt-get update`
- `apt-get install -y vim-common` *(for `xxd` to inspect file)*
- (tests could not run – Flutter/Dart not installed)

------
https://chatgpt.com/codex/tasks/task_e_6880846c26f88332a1bc46489d3ef021