### PR TITLE
Fix missing brace in dispatch function

### DIFF
--- a/flashlights_client/lib/network/osc_listener.dart
+++ b/flashlights_client/lib/network/osc_listener.dart
@@ -295,6 +295,9 @@ class OscListener {
           _sendAck();
         }
         break;
+      }
+
+      // Close the dispatcher function after handling all cases.
     }
 
   /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- close the `_dispatch` function in `osc_listener.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880871a56048332ac24311ddb410580