### PR TITLE
Fix win32 build error note

### DIFF
--- a/flashlights_client/README.md
+++ b/flashlights_client/README.md
@@ -18,3 +18,10 @@ samples, guidance on mobile development, and a full API reference.
 ## iOS build notes
 
 The iOS Runner project uses the `DEVELOPMENT_TEAM` build setting. Set this value in your Xcode environment or define it in `ios/Flutter/Debug.xcconfig` and `ios/Flutter/Release.xcconfig`.
+
+### Flutter dependencies
+
+If you encounter build errors mentioning `UnmodifiableUint8ListView` from the
+`win32` package, your local pub cache is likely using an outdated version of the
+package. Run `flutter pub get` in this directory to refresh dependencies.
+The project requires **Flutter 3.19** (Dart 3.7) or newer.


### PR DESCRIPTION
## Summary
- add guidance on outdated win32 package when building the Flutter client

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68809227f18883328ffdfd503d447f8f