### PR TITLE
Fix Flutter build dependency conflicts

### DIFF
--- a/flashlights_client/pubspec.yaml
+++ b/flashlights_client/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   screen_brightness: ^2.1.5 # Control screen brightness for strobe dimming
   just_audio: ^0.10.4  # Audio playback
   mic_stream: ^0.7.2   # Raw mic samples/recording
-  permission_handler: ^12.0.1  # camera / mic permissions (iOS / Android only)
+  permission_handler: ^11.4.0  # camera / mic permissions (iOS / Android only)
   wakelock: ^0.6.2     # Keep the screen awake during performances
   shared_preferences: ^2.5.3  # Persist selected slot between launches
 


### PR DESCRIPTION
## Summary
- pin `permission_handler` to version range compatible with `mic_stream`
- keep the existing `win32` override to get a newer release

## Testing
- `flutter pub upgrade --major-versions` *(fails: command not found)*
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter build ios --release` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a02a39648332b4356a2f6080b8e6