### PR TITLE
Fix setup script paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ bash
 brew bundle --file=scripts/Brewfile    # installs adb via platform-tools
 flutter --version && adb version
 
+# configure Flutter project for iOS/Android builds
+scripts/setup_platforms.sh
+
 # apply required permissions to AndroidManifest.xml
 scripts/patch_manifests.sh
 

--- a/scripts/setup_platforms.sh
+++ b/scripts/setup_platforms.sh
@@ -5,7 +5,7 @@ echo "🔧 Enabling iOS & Android tool-chains"
 flutter config --enable-ios
 flutter config --enable-android
 
-IOS_PBXPROJ="ios/Runner.xcodeproj/project.pbxproj"
+IOS_PBXPROJ="flashlights_client/ios/Runner.xcodeproj/project.pbxproj"
 IOS_OLD="com.keex.FlashlightsClient"
 IOS_NEW="com.keex.Flashlights-ITD-Client"
 
@@ -16,7 +16,7 @@ else
   perl -pi -e "s/${IOS_OLD}/${IOS_NEW}/g" "${IOS_PBXPROJ}"
 fi
 
-ANDROID_GRADLE="android/app/build.gradle.kts"
+ANDROID_GRADLE="flashlights_client/android/app/build.gradle.kts"
 ANDROID_NAMESPACE_NEW='namespace = "ai.keex.flashlights_client"'
 ANDROID_APPID_NEW='applicationId  = "ai.keex.flashlights_client"'
 


### PR DESCRIPTION
## Summary
- fix path references in `scripts/setup_platforms.sh`
- document running the setup script during Android onboarding

## Testing
- `bash scripts/setup_platforms.sh` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68819d372ab08332a84bf5a30d924523