### PR TITLE
feat: add Simphoni-1v route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,19 @@
+import { Routes, Route } from 'react-router-dom';
+import SimpleChat from './routes/simple-chat';
+import SimplifiRoute from '@/routes/simplifi';
+import Simphoni1vRoute from '@/routes/simphoni-1v';
+
+/* Two routes for SimpleChat */
+// - /simple-chat         => Pro-mode (SimpleChat)
+// - /simplifi            => SimplifiRoute
+// - /simphoni-1v         => Simphoni1vRoute
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/simple-chat" element={<SimpleChat />} />
+      <Route path="/simplifi" element={<SimplifiRoute />} />
+      <Route path="/simphoni-1v" element={<Simphoni1vRoute />} />
+    </Routes>
+  );
+}

--- a/src/routes/simphoni-1v/index.tsx
+++ b/src/routes/simphoni-1v/index.tsx
@@ -1,0 +1,8 @@
+import Simphoni1v from '@/components/Simphoni1v';
+
+/**
+ * Route wrapper for the Simphoni-1v experience without navbar.
+ */
+export default function Simphoni1vRoute() {
+  return <Simphoni1v showNavbar={false} />;
+}


### PR DESCRIPTION
## Summary
- add Simphoni1vRoute import and path in App.jsx
- create Simphoni-1v route wrapper component

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0ae070cc8332bee9f89ce391835e